### PR TITLE
Refine project rail button styles

### DIFF
--- a/src/renderer/components/ProjectRail.test.tsx
+++ b/src/renderer/components/ProjectRail.test.tsx
@@ -101,6 +101,75 @@ afterEach(() => {
   cleanup()
 })
 
+describe('ProjectRail project actions', () => {
+  it('uses a smaller transparent delete target without an active-project ring', () => {
+    i18n.changeLanguage('zh')
+    render(<I18nextProvider i18n={i18n}>
+      <ProjectRail
+        activeProjectId="project-1"
+        activeSkinId="builtin.light.neutral"
+        language="zh"
+        projects={[
+          {
+            id: 'project-1',
+            name: 'Demo',
+            path: '/repo/demo',
+            sort_order: 0,
+            created_at: '2026-08-11T00:00:00.000Z'
+          },
+          {
+            id: 'project-2',
+            name: 'Other',
+            path: '/repo/other',
+            sort_order: 1,
+            created_at: '2026-08-11T00:00:00.000Z'
+          }
+        ]}
+        shellSnapshot={{
+          platform: 'linux',
+          preferences: { version: 2, selection: { mode: 'automatic' } },
+          candidates: [],
+          effectiveShell: null,
+          error: undefined
+        }}
+        onAddProject={() => undefined}
+        onLanguageChange={() => undefined}
+        onOpenAppearance={() => undefined}
+        onDeleteProject={async () => undefined}
+        onOpenAssistant={() => undefined}
+        onOpenDesigner={() => undefined}
+        onRefreshShells={async () => undefined}
+        onReorderProject={() => undefined}
+        onSelectProject={() => undefined}
+        onShellChange={async () => undefined}
+        onSkinChange={() => undefined}
+        userSkins={[]}
+      />
+    </I18nextProvider>)
+
+    const projectButton = screen.getByRole('button', { name: '打开项目 Demo' })
+    const projectButtonClasses = projectButton.className.split(/\s+/)
+    expect(projectButtonClasses).not.toContain('ring-2')
+    expect(projectButtonClasses).not.toContain('ring-primary/20')
+    expect(projectButton.getAttribute('data-variant')).toBe('default')
+    expect(screen.getByRole('button', { name: '打开项目 Other' }).getAttribute('data-variant')).toBe('ghost')
+
+    const deleteButton = screen.getByRole('button', { name: '删除项目 Demo' })
+    const deleteButtonClasses = deleteButton.className.split(/\s+/)
+    expect(deleteButtonClasses).toContain('size-4')
+    expect(deleteButtonClasses).not.toContain('size-6')
+    expect(deleteButtonClasses).toContain('bg-transparent')
+    expect(deleteButtonClasses).toContain('hover:bg-transparent')
+    expect(deleteButtonClasses).toContain('focus-visible:bg-transparent')
+    expect(deleteButtonClasses).toContain('dark:bg-transparent')
+    expect(deleteButtonClasses).toContain('dark:hover:bg-transparent')
+    expect(deleteButtonClasses).toContain('shadow-none')
+    expect(deleteButtonClasses).toContain('opacity-0')
+    expect(deleteButtonClasses).toContain('group-hover:opacity-100')
+    expect(deleteButtonClasses).toContain('focus-visible:opacity-100')
+  })
+})
+
 describe('ProjectRail Shell settings', () => {
   it('shows an unavailable persisted choice and keeps it selected after update rejection', async () => {
     i18n.changeLanguage('zh')

--- a/src/renderer/components/ProjectRail.tsx
+++ b/src/renderer/components/ProjectRail.tsx
@@ -49,7 +49,6 @@ import {
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
-import { cn } from '@/lib/utils'
 
 type ProjectRailProps = {
   projects: ProjectRecord[]
@@ -162,10 +161,7 @@ export function ProjectRail({
                   <TooltipTrigger asChild>
                     <Button
                       aria-label={t('project:action.openProject', { name: project.name })}
-                      className={cn(
-                        'size-10 shrink-0 rounded-xl font-heading text-sm',
-                        isActive && 'ring-2 ring-primary/20'
-                      )}
+                      className="size-10 shrink-0 rounded-xl font-heading text-sm"
                       draggable
                       title={project.path}
                       variant={isActive ? 'default' : 'ghost'}
@@ -186,7 +182,7 @@ export function ProjectRail({
                 </Tooltip>
                 <Button
                   aria-label={t('project:action.deleteProject', { name: project.name })}
-                  className="absolute -top-1 right-0 opacity-0 shadow-sm transition-opacity group-hover:opacity-100"
+                  className="absolute -top-1 right-0 size-4 rounded-sm bg-transparent opacity-0 shadow-none transition-opacity hover:bg-transparent focus-visible:bg-transparent focus-visible:opacity-100 dark:bg-transparent dark:hover:bg-transparent group-hover:opacity-100"
                   size="icon-xs"
                   title={t('project:tooltip.deleteProject')}
                   variant="destructive"


### PR DESCRIPTION
Shrink and transparently style the project delete control, remove the active-project ring while preserving fill-state distinction, and add focused regression coverage.
