### PR TITLE
feat(drafts): persist new-task drafts across sessions

### DIFF
--- a/src/main/database.test.ts
+++ b/src/main/database.test.ts
@@ -24,6 +24,7 @@ import {
   deleteWorkflowWithRevision,
   ensureWorkflowVersion,
   getLastOpenedWorkspace,
+  getTaskDraft,
   getTerminalSessionTranscript,
   listProjects,
   listTerminalSessionMetadataByTask,
@@ -31,11 +32,13 @@ import {
   loadWorkflowVersion,
   openDatabase,
   saveWorkflowWithRevision,
+  saveTaskDraft,
   setLastOpenedWorkspace,
   setProjectDefaultWorkflow,
   updateProjectName,
   type AppDatabase
 } from './database'
+import { TASK_DRAFT_VERSION, type TaskDraftPayload } from '../shared/taskDraft'
 
 const databases: Array<{ db: AppDatabase; dir: string }> = []
 const assumeProjectDirectory = () => true
@@ -87,7 +90,7 @@ function listStoredWorkflows(db: AppDatabase): WorkflowDefinition[] {
   return listWorkflowRecords(db).map((record) => record.workflow)
 }
 
-describe('database schema v1', () => {
+describe('database schema v2', () => {
   it('creates and repairs private local data permissions on POSIX systems', () => {
     if (process.platform === 'win32') return
 
@@ -102,7 +105,7 @@ describe('database schema v1', () => {
 
     tracked.db.close()
     chmodSync(dir, 0o777)
-    chmodSync(databasePath, 0o666)
+    chmodSync(databasePath, 0o000)
     tracked.db = openDatabase(dir)
 
     expect(statSync(dir).mode & 0o777).toBe(0o700)
@@ -160,6 +163,7 @@ describe('database schema v1', () => {
       'process_logs',
       'projects',
       'settings',
+      'task_drafts',
       'tasks',
       'terminal_sessions',
       'workflow_runs',
@@ -167,7 +171,7 @@ describe('database schema v1', () => {
       'workflows'
     ])
     expect(db.pragma('application_id', { simple: true })).toBe(0x434c4c4d)
-    expect(db.pragma('user_version', { simple: true })).toBe(1)
+    expect(db.pragma('user_version', { simple: true })).toBe(2)
 
     const expectedColumns: Record<string, string[]> = {
       projects: ['id', 'name', 'path', 'sort_order', 'default_workflow_id', 'created_at'],
@@ -212,7 +216,16 @@ describe('database schema v1', () => {
         'created_at'
       ],
       workflow_versions: ['workflow_id', 'version', 'definition_json', 'created_at'],
-      settings: ['key', 'value_json', 'updated_at']
+      settings: ['key', 'value_json', 'updated_at'],
+      task_drafts: [
+        'project_id',
+        'workflow_id',
+        'workflow_json',
+        'variables_json',
+        'revision',
+        'created_at',
+        'updated_at'
+      ]
     }
     for (const [table, columns] of Object.entries(expectedColumns)) {
       const actual = (db.prepare(`pragma table_info(${table})`).all() as Array<{ name: string }>)
@@ -237,6 +250,7 @@ describe('database schema v1', () => {
       'idx_hook_runs_task_id',
       'idx_process_logs_task_id',
       'idx_process_logs_task_node_created',
+      'idx_task_drafts_updated_at',
       'idx_tasks_project_id',
       'idx_terminal_sessions_node_id',
       'idx_terminal_sessions_task_id',
@@ -260,7 +274,7 @@ describe('database schema v1', () => {
 
     expect(listProjects(tracked.db)).toEqual([project])
     expect(tracked.db.pragma('application_id', { simple: true })).toBe(0x434c4c4d)
-    expect(tracked.db.pragma('user_version', { simple: true })).toBe(1)
+    expect(tracked.db.pragma('user_version', { simple: true })).toBe(2)
   })
 
   it('can retry after schema initialization fails without publishing a partial database', () => {
@@ -287,7 +301,7 @@ describe('database schema v1', () => {
     const db = openDatabase(dir)
     databases.push({ db, dir })
     expect(db.pragma('application_id', { simple: true })).toBe(0x434c4c4d)
-    expect(db.pragma('user_version', { simple: true })).toBe(1)
+    expect(db.pragma('user_version', { simple: true })).toBe(2)
   })
 
   it.each([1, 16])(
@@ -347,17 +361,35 @@ describe('database schema v1', () => {
       const futureDb = new Database(databasePath)
       futureDb.exec('create table future_data (value text not null)')
       futureDb.pragma('application_id = 1129073741')
-      futureDb.pragma('user_version = 2')
+      futureDb.pragma('user_version = 3')
       futureDb.close()
       const bytesBefore = readFileSync(databasePath)
       const filesBefore = readdirSync(dir).sort()
 
-      expect(() => openDatabase(dir)).toThrow('Unsupported database schema version: 2')
+      expect(() => openDatabase(dir)).toThrow('Unsupported database schema version: 3')
       expect(readFileSync(databasePath).equals(bytesBefore)).toBe(true)
       expect(readdirSync(dir).sort()).toEqual(filesBefore)
     } finally {
       rmSync(dir, { recursive: true, force: true })
     }
+  })
+
+  it('migrates an existing schema v1 database to the draft schema', () => {
+    const tracked = createTrackedDatabase('cliloom-schema-migration-')
+    const project = addProject(tracked.db, '/repo/schema-migration', assumeProjectDirectory)
+    tracked.db.exec('drop index idx_task_drafts_updated_at; drop table task_drafts;')
+    tracked.db.pragma('user_version = 1')
+    tracked.db.close()
+
+    tracked.db = openDatabase(tracked.dir)
+
+    expect(tracked.db.pragma('user_version', { simple: true })).toBe(2)
+    expect(listProjects(tracked.db)).toEqual([project])
+    expect(
+      tracked.db.prepare(
+        "select name from sqlite_master where type = 'table' and name = 'task_drafts'"
+      ).get()
+    ).toEqual({ name: 'task_drafts' })
   })
 })
 
@@ -475,6 +507,91 @@ describe('last opened workspace', () => {
 
     deleteProject(db, project.id)
     expect(getLastOpenedWorkspace(db)).toBeNull()
+  })
+})
+
+describe('task draft persistence', () => {
+  function draftPayload(revision: number, prompt = 'saved prompt'): TaskDraftPayload {
+    return {
+      version: TASK_DRAFT_VERSION,
+      workflow: {
+        ...databaseWorkflow,
+        nodes: [
+          {
+            id: 'start',
+            type: 'start',
+            name: 'Start',
+            config: {
+              variables: [{
+                key: 'prompt',
+                label: 'Prompt',
+                type: 'text',
+                required: false,
+                defaultValue: 'default'
+              }]
+            }
+          },
+          ...databaseWorkflow.nodes.slice(1)
+        ]
+      },
+      variables: { prompt },
+      revision
+    }
+  }
+
+  it('round-trips one draft per project and ignores stale revisions', () => {
+    const tracked = createTrackedDatabase()
+    const project = addProject(tracked.db, '/repo/task-draft', assumeProjectDirectory)
+
+    const saved = saveTaskDraft(tracked.db, project.id, draftPayload(1))
+    expect(saved).toMatchObject({
+      projectId: project.id,
+      workflow: expect.objectContaining({ id: databaseWorkflow.id }),
+      variables: { prompt: 'saved prompt' },
+      revision: 1
+    })
+
+    const newer = saveTaskDraft(tracked.db, project.id, draftPayload(2, 'newer prompt'))
+    expect(newer.variables).toEqual({ prompt: 'newer prompt' })
+    const stale = saveTaskDraft(tracked.db, project.id, draftPayload(1, 'stale prompt'))
+    expect(stale.variables).toEqual({ prompt: 'newer prompt' })
+    expect(getTaskDraft(tracked.db, project.id)?.variables).toEqual({ prompt: 'newer prompt' })
+
+    const overwritten = saveTaskDraft(
+      tracked.db,
+      project.id,
+      draftPayload(1, 'fresh prompt'),
+      { overwrite: true }
+    )
+    expect(overwritten.variables).toEqual({ prompt: 'fresh prompt' })
+    expect(overwritten.revision).toBeGreaterThan(newer.revision)
+    expect(saveTaskDraft(tracked.db, project.id, draftPayload(2, 'late stale prompt')).variables)
+      .toEqual({ prompt: 'fresh prompt' })
+
+    tracked.db.close()
+    tracked.db = openDatabase(tracked.dir)
+    expect(getTaskDraft(tracked.db, project.id)?.variables).toEqual({ prompt: 'fresh prompt' })
+  })
+
+  it('removes a project draft when the project is deleted', () => {
+    const { db } = createTrackedDatabase()
+    const project = addProject(db, '/repo/task-draft-delete', assumeProjectDirectory)
+    saveTaskDraft(db, project.id, draftPayload(1))
+
+    deleteProject(db, project.id)
+
+    expect(getTaskDraft(db, project.id)).toBeNull()
+  })
+
+  it('rejects malformed drafts and drafts for unknown projects', () => {
+    const { db } = createTrackedDatabase()
+    const project = addProject(db, '/repo/task-draft-validation', assumeProjectDirectory)
+
+    expect(() => saveTaskDraft(db, 'missing-project', draftPayload(1))).toThrow()
+    expect(() => saveTaskDraft(db, project.id, {
+      ...draftPayload(1),
+      variables: { prompt: { nested: true } }
+    })).toThrow()
   })
 })
 

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -25,6 +25,11 @@ import {
   type WorkflowDefinition
 } from '../shared/workflow'
 import {
+  parseTaskDraftPayload,
+  TASK_DRAFT_VERSION,
+  type TaskDraftRecord
+} from '../shared/taskDraft'
+import {
   MAX_PERSISTED_TERMINAL_TRANSCRIPT_CHARS,
   tailText
 } from '../shared/terminalBuffer'
@@ -61,7 +66,8 @@ export type TaskSummaryRecord = Omit<TaskRecord, 'context_json'>
 
 export const DATABASE_FILENAME = `${APP_SLUG}.db`
 const DATABASE_APPLICATION_ID = 0x434c4c4d
-const CURRENT_SCHEMA_VERSION = 1
+const CURRENT_SCHEMA_VERSION = 2
+const INITIAL_SCHEMA_VERSION = 1
 const SQLITE_HEADER_LENGTH = 72
 const SQLITE_MAGIC = Buffer.from('SQLite format 3\0')
 const PRIVATE_DIRECTORY_MODE = 0o700
@@ -71,9 +77,10 @@ export function openDatabase(userDataPath: string): AppDatabase {
   ensurePrivateDataDirectory(userDataPath)
   const databasePath = path.join(userDataPath, DATABASE_FILENAME)
   const databaseExists = existsSync(databasePath)
+  let existingSchemaVersion: number | null = null
   if (databaseExists) {
     ensurePrivateDataFile(databasePath)
-    assertCurrentDatabaseLineage(databasePath)
+    existingSchemaVersion = readDatabaseSchemaVersion(databasePath)
   } else {
     createCurrentDatabase(databasePath)
     ensurePrivateDataFile(databasePath)
@@ -82,6 +89,9 @@ export function openDatabase(userDataPath: string): AppDatabase {
   const db = new Database(databasePath, { fileMustExist: true })
   try {
     db.pragma('journal_mode = WAL')
+    if (existingSchemaVersion !== null && existingSchemaVersion < CURRENT_SCHEMA_VERSION) {
+      migrateDatabase(db, existingSchemaVersion)
+    }
     ensurePrivateSqliteFiles(databasePath)
     return db
   } catch (error) {
@@ -141,7 +151,7 @@ function removeInitializationFiles(initializationPath: string): void {
   }
 }
 
-function assertCurrentDatabaseLineage(databasePath: string): void {
+function readDatabaseSchemaVersion(databasePath: string): number {
   const file = openSync(databasePath, 'r')
   try {
     const header = Buffer.alloc(SQLITE_HEADER_LENGTH)
@@ -156,9 +166,10 @@ function assertCurrentDatabaseLineage(databasePath: string): void {
         t('errors:database.unsupportedSchemaDetected', { path: databasePath })
       )
     }
-    if (schemaVersion !== CURRENT_SCHEMA_VERSION) {
+    if (schemaVersion < INITIAL_SCHEMA_VERSION || schemaVersion > CURRENT_SCHEMA_VERSION) {
       throw new Error(t('errors:database.unsupportedSchema', { version: schemaVersion }))
     }
+    return schemaVersion
   } finally {
     closeSync(file)
   }
@@ -276,6 +287,16 @@ function initializeCurrentSchema(db: AppDatabase): void {
         updated_at text not null
       );
 
+      create table task_drafts (
+        project_id text primary key,
+        workflow_id text not null,
+        workflow_json text not null,
+        variables_json text not null,
+        revision integer not null default 1,
+        created_at text not null,
+        updated_at text not null
+      );
+
       create index idx_tasks_project_id on tasks(project_id);
       create index idx_terminal_sessions_task_id on terminal_sessions(task_id);
       create index idx_terminal_sessions_node_id on terminal_sessions(node_id);
@@ -288,11 +309,42 @@ function initializeCurrentSchema(db: AppDatabase): void {
         on workflow_runs(workflow_id, workflow_version);
       create index idx_workflow_versions_workflow_id on workflow_versions(workflow_id);
       create index idx_edges_workflow_id on edges(workflow_id);
+      create index idx_task_drafts_updated_at on task_drafts(updated_at);
     `)
     db.pragma(`application_id = ${DATABASE_APPLICATION_ID}`)
     db.pragma(`user_version = ${CURRENT_SCHEMA_VERSION}`)
   })
   initialize()
+}
+
+function migrateDatabase(db: AppDatabase, fromVersion: number): void {
+  if (fromVersion < INITIAL_SCHEMA_VERSION || fromVersion > CURRENT_SCHEMA_VERSION) {
+    throw new Error(t('errors:database.unsupportedSchema', { version: fromVersion }))
+  }
+
+  if (fromVersion === 1) {
+    const migrateV2 = db.transaction(() => {
+      db.exec(`
+        create table if not exists task_drafts (
+          project_id text primary key,
+          workflow_id text not null,
+          workflow_json text not null,
+          variables_json text not null,
+          revision integer not null default 1,
+          created_at text not null,
+          updated_at text not null
+        );
+        create index if not exists idx_task_drafts_updated_at on task_drafts(updated_at);
+      `)
+      db.pragma(`user_version = ${CURRENT_SCHEMA_VERSION}`)
+    })
+    migrateV2()
+    return
+  }
+
+  if (fromVersion !== CURRENT_SCHEMA_VERSION) {
+    throw new Error(t('errors:database.unsupportedSchema', { version: fromVersion }))
+  }
 }
 
 export type WorkflowRecord = {
@@ -634,6 +686,7 @@ export function deleteProject(db: AppDatabase, projectId: string): void {
       db.prepare('delete from node_runs where run_id in (select id from workflow_runs where task_id = ?)').run(taskId)
       db.prepare('delete from workflow_runs where task_id = ?').run(taskId)
     }
+    db.prepare('delete from task_drafts where project_id = ?').run(projectId)
     db.prepare('delete from tasks where project_id = ?').run(projectId)
     db.prepare('delete from projects where id = ?').run(projectId)
   })
@@ -696,6 +749,134 @@ export function getTaskContext(db: AppDatabase, taskId: string): string | null {
   const row = db.prepare('select context_json from tasks where id = ?').get(taskId) as
     { context_json: string } | undefined
   return row?.context_json ?? null
+}
+
+type TaskDraftRow = {
+  project_id: string
+  workflow_id: string
+  workflow_json: string
+  variables_json: string
+  revision: number
+  created_at: string
+  updated_at: string
+}
+
+export function getTaskDraft(db: AppDatabase, projectId: string): TaskDraftRecord | null {
+  const row = db.prepare(
+    `select project_id, workflow_id, workflow_json, variables_json, revision, created_at, updated_at
+     from task_drafts
+     where project_id = ? and exists (
+       select 1 from projects where projects.id = task_drafts.project_id
+     )`
+  ).get(projectId) as TaskDraftRow | undefined
+  if (!row) return null
+
+  try {
+    const workflow = JSON.parse(row.workflow_json) as unknown
+    const variables = JSON.parse(row.variables_json) as unknown
+    const payload = parseTaskDraftPayload({
+      version: TASK_DRAFT_VERSION,
+      workflow,
+      variables,
+      revision: row.revision
+    })
+    if (payload.workflow.id !== row.workflow_id) return null
+    return {
+      ...payload,
+      projectId: row.project_id,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at
+    }
+  } catch (error) {
+    console.warn(`[CLILoom task draft] skipped unreadable draft for project ${projectId}:`, error)
+    return null
+  }
+}
+
+export function saveTaskDraft(
+  db: AppDatabase,
+  projectId: unknown,
+  value: unknown,
+  options: { overwrite?: boolean } = {}
+): TaskDraftRecord {
+  assertTaskDraftProjectId(projectId)
+  const project = db.prepare('select id from projects where id = ?').get(projectId)
+  if (!project) throw new NotFoundError(t('errors:database.projectNotFound'))
+
+  const payload = parseTaskDraftPayload(value)
+  const now = new Date().toISOString()
+  const existing = db.prepare(
+    'select revision, created_at from task_drafts where project_id = ?'
+  ).get(projectId) as { revision: number; created_at: string } | undefined
+
+  const persist = db.transaction(() => {
+    if (!options.overwrite && existing && existing.revision > payload.revision) return
+    const revision = options.overwrite && existing &&
+      Number.isSafeInteger(existing.revision) &&
+      existing.revision >= 1 &&
+      existing.revision < Number.MAX_SAFE_INTEGER
+      ? Math.max(payload.revision, existing.revision + 1)
+      : payload.revision
+    if (existing) {
+      if (options.overwrite) {
+        db.prepare(
+          `update task_drafts
+           set workflow_id = ?, workflow_json = ?, variables_json = ?, revision = ?, updated_at = ?
+           where project_id = ?`
+        ).run(
+          payload.workflow.id,
+          JSON.stringify(payload.workflow),
+          JSON.stringify(payload.variables),
+          revision,
+          now,
+          projectId
+        )
+      } else {
+        db.prepare(
+          `update task_drafts
+           set workflow_id = ?, workflow_json = ?, variables_json = ?, revision = ?, updated_at = ?
+           where project_id = ? and revision <= ?`
+        ).run(
+          payload.workflow.id,
+          JSON.stringify(payload.workflow),
+          JSON.stringify(payload.variables),
+          revision,
+          now,
+          projectId,
+          revision
+        )
+      }
+      return
+    }
+    db.prepare(
+      `insert into task_drafts
+        (project_id, workflow_id, workflow_json, variables_json, revision, created_at, updated_at)
+       values (?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      projectId,
+      payload.workflow.id,
+      JSON.stringify(payload.workflow),
+      JSON.stringify(payload.variables),
+      revision,
+      now,
+      now
+    )
+  })
+  persist()
+
+  const saved = getTaskDraft(db, projectId)
+  if (!saved) throw new Error(t('errors:database.taskDraftInvalid'))
+  return saved
+}
+
+export function deleteTaskDraft(db: AppDatabase, projectId: string): void {
+  db.prepare('delete from task_drafts where project_id = ?').run(projectId)
+}
+
+function assertTaskDraftProjectId(value: unknown): asserts value is string {
+  if (typeof value !== 'string' || !value || value.length > 512 || value.includes('\0')) {
+    throw new Error(t('errors:database.projectNotFound'))
+  }
 }
 
 export type TerminalSessionRecord = {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -17,13 +17,16 @@ import { MAX_IMPORT_BYTES } from '../shared/skin'
 import { initMainI18n, setMainI18nLanguage, t } from './i18n'
 import {
   addProject,
+  deleteTaskDraft,
   getLastOpenedWorkspace,
+  getTaskDraft,
   getTaskContext,
   listProjects,
   listTasks,
   openDatabase,
   reorderProjects,
   setLastOpenedWorkspace,
+  saveTaskDraft,
   updateProjectName,
   updateTaskTitle,
   type AppDatabase
@@ -73,6 +76,7 @@ import { InstalledFontService } from './installedFonts'
 import { createElectronUpdaterAdapter } from './electronUpdaterAdapter'
 import { coordinateUpdateInstall } from './updateInstallCoordinator'
 import { readUpdatePackageTypeMarker, UpdateService } from './updateService'
+import { waitForRendererDraftFlush } from './rendererDraftFlush'
 import {
   createSecureWebPreferences,
   installDevToolsShortcut,
@@ -166,7 +170,10 @@ function startDesktopApplication(): void {
     resolveExecutablePath: (candidate) => resolvePortableExecutablePath({
       PORTABLE_EXECUTABLE_FILE: candidate
     }, process.platform),
-    cleanupCurrent: beginSafeApplicationCleanup,
+    cleanupCurrent: async () => {
+      await flushRendererDraftBeforeQuit()
+      await beginSafeApplicationCleanup()
+    },
     onCleanupFailed: (error) => {
       quitCleanup = null
       showUnsafeExitError(error)
@@ -359,9 +366,9 @@ function showReplacementLaunchFailed(error: unknown): void {
 }
 
 function quitAfterInstanceHandoff(): void {
-  allowMainWindowDestroy = true
-  allowApplicationQuit = true
-  app.quit()
+  // The replacement may take a moment to launch. Flush once more here so any
+  // edits made while that handoff was in progress are included as well.
+  void completeNormalApplicationQuit()
 }
 
 async function showHandoffUnavailableDialog(incoming: DesktopInstanceLaunchData): Promise<void> {
@@ -434,6 +441,7 @@ function beginSafeApplicationCleanup(): Promise<void> {
 
 async function completeNormalApplicationQuit(): Promise<void> {
   try {
+    await flushRendererDraftBeforeQuit()
     await beginSafeApplicationCleanup()
     allowMainWindowDestroy = true
     allowApplicationQuit = true
@@ -443,6 +451,14 @@ async function completeNormalApplicationQuit(): Promise<void> {
     quitCleanup = null
     showUnsafeExitError(error)
     if (!mainWindow && app.isReady() && desktopInitialized) createWindow()
+  }
+}
+
+async function flushRendererDraftBeforeQuit(): Promise<void> {
+  if (mainWindowClosing) {
+    await mainWindowClosing
+  } else if (mainWindow && !mainWindow.isDestroyed()) {
+    await waitForRendererDraftFlush(mainWindow, ipcMain, isMainSender)
   }
 }
 
@@ -521,6 +537,7 @@ function installMainWindowListeners(window: BrowserWindow): void {
     if (mainWindowClosing) return
     mainWindowClosing = (async () => {
       saveMainWindowState(window)
+      await waitForRendererDraftFlush(window, ipcMain, isMainSender)
       allowMainWindowDestroy = true
       if (!window.isDestroyed()) window.destroy()
     })().finally(() => {
@@ -725,7 +742,10 @@ function registerIpc(): void {
     }
     try {
       await coordinateUpdateInstall({
-        cleanup: beginSafeApplicationCleanup,
+        cleanup: async () => {
+          await flushRendererDraftBeforeQuit()
+          await beginSafeApplicationCleanup()
+        },
         allowQuit: () => {
           allowMainWindowDestroy = true
           allowApplicationQuit = true
@@ -794,6 +814,27 @@ function registerIpc(): void {
   ipcMain.handle('tasks:context', (event, taskId: string) => {
     assertMainSender(event)
     return getTaskContext(db, taskId)
+  })
+  ipcMain.handle('tasks:draft:get', (event, projectId: string) => {
+    assertMainSender(event)
+    if (typeof projectId !== 'string' || !projectId) {
+      throw new Error(t('errors:database.projectNotFound'))
+    }
+    return getTaskDraft(db, projectId)
+  })
+  ipcMain.handle('tasks:draft:save', (event, projectId: unknown, draft: unknown, overwrite?: unknown) => {
+    assertMainSender(event)
+    if (overwrite !== undefined && typeof overwrite !== 'boolean') {
+      throw new Error(t('errors:database.taskDraftInvalid'))
+    }
+    return saveTaskDraft(db, projectId, draft, { overwrite: overwrite === true })
+  })
+  ipcMain.handle('tasks:draft:delete', (event, projectId: string) => {
+    assertMainSender(event)
+    if (typeof projectId !== 'string' || !projectId) {
+      throw new Error(t('errors:database.projectNotFound'))
+    }
+    return deleteTaskDraft(db, projectId)
   })
   ipcMain.handle('tasks:delete', async (event, taskId: string) => {
     assertMainSender(event)

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -4,6 +4,7 @@ import type { ShellSnapshot } from '../shared/shell'
 import type { TerminalDataEvent, TerminalTranscriptSnapshot } from '../shared/terminalBuffer'
 import type { UpdateState } from '../shared/update'
 import type { TerminalClosedEvent, TerminalRetryMode } from '../shared/terminalSession'
+import type { TaskDraftPayload, TaskDraftRecord } from '../shared/taskDraft'
 
 const api = {
   rendererNoSandboxSwitch: process.argv.includes('--no-sandbox'),
@@ -47,6 +48,12 @@ const api = {
   setProjectDefaultWorkflow: (projectId: string, workflowId: string) => ipcRenderer.invoke('projects:setDefaultWorkflow', projectId, workflowId),
   listTasks: (projectId: string) => ipcRenderer.invoke('tasks:list', projectId),
   getTaskContext: (taskId: string) => ipcRenderer.invoke('tasks:context', taskId) as Promise<string | null>,
+  getTaskDraft: (projectId: string) => ipcRenderer.invoke('tasks:draft:get', projectId) as Promise<TaskDraftRecord | null>,
+  saveTaskDraft: (projectId: string, draft: TaskDraftPayload, overwrite = false) =>
+    (overwrite
+      ? ipcRenderer.invoke('tasks:draft:save', projectId, draft, true)
+      : ipcRenderer.invoke('tasks:draft:save', projectId, draft)) as Promise<TaskDraftRecord>,
+  deleteTaskDraft: (projectId: string) => ipcRenderer.invoke('tasks:draft:delete', projectId) as Promise<void>,
   listTaskSessions: (taskId: string) => ipcRenderer.invoke('tasks:sessions', taskId),
   getTaskSessionTranscript: (taskId: string, sessionId: string) =>
     ipcRenderer.invoke('tasks:session-transcript', taskId, sessionId) as Promise<TerminalTranscriptSnapshot>,
@@ -77,6 +84,12 @@ const api = {
       ipcRenderer.removeListener('workflow:state', listener)
     }
   },
+  onPrepareToClose: (callback: () => void) => {
+    const listener = () => callback()
+    ipcRenderer.on('app:prepare-to-close', listener)
+    return () => ipcRenderer.removeListener('app:prepare-to-close', listener)
+  },
+  rendererReadyToClose: () => ipcRenderer.send('app:renderer-ready-to-close'),
   onTerminalCreated: (callback: (event: unknown) => void) => {
     const listener = (_event: Electron.IpcRendererEvent, payload: unknown) => callback(payload)
     ipcRenderer.on('terminal:created', listener)

--- a/src/main/rendererDraftFlush.test.ts
+++ b/src/main/rendererDraftFlush.test.ts
@@ -1,0 +1,67 @@
+import { EventEmitter } from 'node:events'
+import type { BrowserWindow, IpcMain, IpcMainEvent, WebContents } from 'electron'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { waitForRendererDraftFlush } from './rendererDraftFlush'
+
+function createHarness() {
+  const ipc = new EventEmitter()
+  const webContents = { send: vi.fn() } as unknown as WebContents
+  const window = {
+    isDestroyed: vi.fn(() => false),
+    webContents
+  } as unknown as BrowserWindow
+  return {
+    ipc,
+    typedIpc: ipc as unknown as Pick<IpcMain, 'on' | 'removeListener'>,
+    webContents,
+    window
+  }
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('renderer draft close handshake', () => {
+  it('stops waiting after the timeout when the renderer does not respond', async () => {
+    vi.useFakeTimers()
+    const { ipc, typedIpc, webContents, window } = createHarness()
+    const operation = waitForRendererDraftFlush(window, typedIpc, () => true, 2_000)
+    let completed = false
+    void operation.then(() => {
+      completed = true
+    })
+
+    expect(webContents.send).toHaveBeenCalledWith('app:prepare-to-close')
+    expect(ipc.listenerCount('app:renderer-ready-to-close')).toBe(1)
+    await vi.advanceTimersByTimeAsync(1_999)
+    expect(completed).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(1)
+    await operation
+
+    expect(completed).toBe(true)
+    expect(ipc.listenerCount('app:renderer-ready-to-close')).toBe(0)
+  })
+
+  it('ignores unrelated acknowledgements and accepts the trusted window', async () => {
+    vi.useFakeTimers()
+    const { ipc, typedIpc, webContents, window } = createHarness()
+    const isTrustedSender = vi.fn((event: IpcMainEvent) => event.sender === webContents)
+    const operation = waitForRendererDraftFlush(window, typedIpc, isTrustedSender)
+    let completed = false
+    void operation.then(() => {
+      completed = true
+    })
+
+    ipc.emit('app:renderer-ready-to-close', { sender: {} })
+    await Promise.resolve()
+    expect(completed).toBe(false)
+
+    ipc.emit('app:renderer-ready-to-close', { sender: webContents })
+    await operation
+
+    expect(completed).toBe(true)
+    expect(ipc.listenerCount('app:renderer-ready-to-close')).toBe(0)
+  })
+})

--- a/src/main/rendererDraftFlush.ts
+++ b/src/main/rendererDraftFlush.ts
@@ -1,0 +1,35 @@
+import type { BrowserWindow, IpcMain, IpcMainEvent } from 'electron'
+
+export const RENDERER_DRAFT_FLUSH_TIMEOUT_MS = 2_000
+
+export function waitForRendererDraftFlush(
+  window: BrowserWindow,
+  ipc: Pick<IpcMain, 'on' | 'removeListener'>,
+  isTrustedSender: (event: IpcMainEvent) => boolean,
+  timeoutMs = RENDERER_DRAFT_FLUSH_TIMEOUT_MS
+): Promise<void> {
+  if (window.isDestroyed()) return Promise.resolve()
+
+  return new Promise((resolve) => {
+    let settled = false
+    const finish = () => {
+      if (settled) return
+      settled = true
+      clearTimeout(timeout)
+      ipc.removeListener('app:renderer-ready-to-close', onReady)
+      resolve()
+    }
+    const timeout = setTimeout(finish, timeoutMs)
+    const onReady = (event: IpcMainEvent) => {
+      if (event.sender !== window.webContents || !isTrustedSender(event)) return
+      finish()
+    }
+
+    ipc.on('app:renderer-ready-to-close', onReady)
+    try {
+      window.webContents.send('app:prepare-to-close')
+    } catch {
+      finish()
+    }
+  })
+}

--- a/src/renderer/App.test.tsx
+++ b/src/renderer/App.test.tsx
@@ -12,7 +12,7 @@ import {
   DEFAULT_SHELL_PREFERENCES
 } from '../shared/appSettings'
 import { DEFAULT_SKIN } from './theme'
-import type { WorkflowDefinition, WorkflowNode } from '../shared/workflow'
+import type { VariableDefinition, WorkflowDefinition, WorkflowNode } from '../shared/workflow'
 import type {
   WorkflowRuntimeBranchRun,
   WorkflowRuntimeStartOptions,
@@ -21,6 +21,7 @@ import type {
 import type { ShellSnapshot } from '../shared/shell'
 import type { TerminalDataEvent, TerminalTranscriptSnapshot } from '../shared/terminalBuffer'
 import type { UpdateState } from '../shared/update'
+import { TASK_DRAFT_VERSION, type TaskDraftPayload, type TaskDraftRecord } from '../shared/taskDraft'
 import type {
   Bootstrap,
   ProjectRecord,
@@ -646,7 +647,25 @@ function runtimeState(
   }
 }
 
+function taskDraft(
+  projectId: string,
+  definition: WorkflowDefinition,
+  variables: Record<string, string | number | boolean | null>,
+  revision = 1
+): TaskDraftRecord {
+  return {
+    projectId,
+    version: TASK_DRAFT_VERSION,
+    workflow: definition,
+    variables,
+    revision,
+    createdAt: '2026-08-05T00:00:00.000Z',
+    updatedAt: '2026-08-05T00:00:00.000Z'
+  }
+}
+
 type Listeners = {
+  prepareToClose?: () => void
   shellsChanged?: (snapshot: ShellSnapshot) => void
   settingsChanged?: (snapshot: Bootstrap['settings']) => void
   workflowState?: (state: WorkflowRuntimeState) => void
@@ -657,6 +676,7 @@ type Listeners = {
 
 function setupApi(options: {
   data?: ReturnType<typeof bootstrap>
+  drafts?: Record<string, TaskDraftRecord | null>
   restore?: {
     state: WorkflowRuntimeState
     workflow: WorkflowDefinition
@@ -667,6 +687,9 @@ function setupApi(options: {
   const data = options.data ?? bootstrap()
   const listeners: Listeners = {}
   let workflowRecords = data.workflowRecords
+  const draftStore = new Map<string, TaskDraftRecord>(
+    Object.entries(options.drafts ?? {}).filter((entry): entry is [string, TaskDraftRecord] => Boolean(entry[1]))
+  )
   const unsubscribe = () => {}
   const initialUpdateState: UpdateState = options.updateState ?? {
     status: 'idle',
@@ -680,6 +703,26 @@ function setupApi(options: {
     listWorkflows: vi.fn(() => Promise.resolve(workflowRecords)),
     restoreWorkflowState: vi.fn().mockResolvedValue(options.restore ?? null),
     getTaskContext: vi.fn().mockResolvedValue('{}'),
+    getTaskDraft: vi.fn((projectId: string) => Promise.resolve(draftStore.get(projectId) ?? null)),
+    saveTaskDraft: vi.fn((projectId: string, draft: TaskDraftPayload, overwrite = false) => {
+      const existing = draftStore.get(projectId)
+      const now = '2026-08-05T00:00:00.000Z'
+      const saved: TaskDraftRecord = {
+        ...draft,
+        projectId,
+        revision: overwrite && existing
+          ? Math.max(draft.revision, existing.revision + 1)
+          : draft.revision,
+        createdAt: existing?.createdAt ?? now,
+        updatedAt: now
+      }
+      draftStore.set(projectId, saved)
+      return Promise.resolve(saved)
+    }),
+    deleteTaskDraft: vi.fn((projectId: string) => {
+      draftStore.delete(projectId)
+      return Promise.resolve()
+    }),
     listTaskSessions: vi.fn().mockResolvedValue([]),
     getTaskSessionTranscript: vi.fn().mockResolvedValue({
       transcript: 'loaded transcript',
@@ -730,6 +773,11 @@ function setupApi(options: {
       listeners.workflowState = callback
       return unsubscribe
     }),
+    onPrepareToClose: vi.fn((callback: () => void) => {
+      listeners.prepareToClose = callback
+      return unsubscribe
+    }),
+    rendererReadyToClose: vi.fn(),
     onTerminalCreated: vi.fn(() => unsubscribe),
     onTerminalRestarted: vi.fn(() => unsubscribe),
     onTerminalData: vi.fn((callback: (event: TerminalDataEvent) => void) => {
@@ -737,6 +785,11 @@ function setupApi(options: {
       return unsubscribe
     }),
     onTerminalClosed: vi.fn(() => unsubscribe)
+  }
+  if (options.drafts === undefined) {
+    Reflect.deleteProperty(api, 'getTaskDraft')
+    Reflect.deleteProperty(api, 'saveTaskDraft')
+    Reflect.deleteProperty(api, 'deleteTaskDraft')
   }
   Object.defineProperty(window, 'cliLoom', {
     configurable: true,
@@ -748,7 +801,8 @@ function setupApi(options: {
     listeners,
     setWorkflowRecords: (records: WorkflowRecord[]) => {
       workflowRecords = records
-    }
+    },
+    draftStore
   }
 }
 
@@ -997,8 +1051,178 @@ describe('App task workflow selection', () => {
     expect((await screen.findByLabelText('Select workflow')).getAttribute('title')).toBe('流程 A')
   })
 
+  it('restores a project draft only when New task is clicked', async () => {
+    const cachedDraft = taskDraft(project.id, workflowA, { prompt: 'cached prompt' }, 7)
+    const { api } = setupApi({ drafts: { [project.id]: cachedDraft } })
+    const newTaskButton = await renderBootstrappedApp()
+
+    expect(screen.getByTestId('variables').textContent).toContain('default a')
+    expect(api.getTaskDraft).not.toHaveBeenCalled()
+
+    fireEvent.click(newTaskButton)
+
+    await waitFor(() => expect(api.getTaskDraft).toHaveBeenCalledWith(project.id))
+    await waitFor(() => expect(screen.getByTestId('variables').textContent).toContain('cached prompt'))
+  })
+
+  it('keeps drafts scoped to a project while switching projects', async () => {
+    const data = bootstrap()
+    data.projects = [project, otherProject]
+    const { api } = setupApi({
+      data,
+      drafts: { [project.id]: taskDraft(project.id, workflowA, { prompt: 'project one' }) }
+    })
+
+    await renderBootstrappedApp()
+    fireEvent.click(screen.getByRole('button', { name: '新建任务' }))
+    await waitFor(() => expect(screen.getByTestId('variables').textContent).toContain('project one'))
+
+    fireEvent.click(screen.getByRole('button', { name: '切换项目 Other Project' }))
+    await waitFor(() => expect(api.listTasks).toHaveBeenCalledWith(otherProject.id))
+    expect(api.getTaskDraft).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(screen.getByRole('button', { name: '切换项目 Project' }))
+    await waitFor(() => expect(api.listTasks).toHaveBeenCalledWith(project.id))
+    expect(api.getTaskDraft).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(screen.getByRole('button', { name: '新建任务' }))
+    await waitFor(() => expect(api.getTaskDraft).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(screen.getByTestId('variables').textContent).toContain('project one'))
+  })
+
+  it('flushes a debounced draft edit before switching projects', async () => {
+    const data = bootstrap()
+    data.projects = [project, otherProject]
+    const { api, draftStore } = setupApi({ data, drafts: {} })
+    const newTaskButton = await renderBootstrappedApp()
+    fireEvent.click(newTaskButton)
+    await waitFor(() => expect(draftStore.get(project.id)?.variables).toEqual({ prompt: 'default a' }))
+    const callsBeforeEdit = api.saveTaskDraft.mock.calls.length
+
+    fireEvent.click(screen.getByRole('button', { name: '修改变量' }))
+    expect(api.saveTaskDraft).toHaveBeenCalledTimes(callsBeforeEdit)
+    fireEvent.click(screen.getByRole('button', { name: '切换项目 Other Project' }))
+
+    await waitFor(() => expect(api.listTasks).toHaveBeenCalledWith(otherProject.id))
+    expect(draftStore.get(project.id)?.variables).toEqual({ prompt: 'edited prompt' })
+  })
+
+  it('replaces an existing draft with fresh defaults when New task is clicked again', async () => {
+    const cachedDraft = taskDraft(project.id, workflowA, { prompt: 'old draft' }, 3)
+    const { draftStore } = setupApi({ drafts: { [project.id]: cachedDraft } })
+    const newTaskButton = await renderBootstrappedApp()
+
+    fireEvent.click(newTaskButton)
+    await waitFor(() => expect(screen.getByTestId('variables').textContent).toContain('old draft'))
+
+    fireEvent.click(newTaskButton)
+
+    await waitFor(() => expect(screen.getByTestId('variables').textContent).toContain('default a'))
+    await waitFor(() => expect(draftStore.get(project.id)?.variables).toEqual({ prompt: 'default a' }))
+  })
+
+  it('overwrites an existing draft when New task is clicked again before the first lookup finishes', async () => {
+    const cachedDraft = taskDraft(project.id, workflowA, { prompt: 'old draft' }, 9)
+    const { api, draftStore } = setupApi({ drafts: { [project.id]: cachedDraft } })
+    const pendingLookup = deferred<TaskDraftRecord | null>()
+    api.getTaskDraft.mockReturnValueOnce(pendingLookup.promise)
+    const newTaskButton = await renderBootstrappedApp()
+
+    fireEvent.click(newTaskButton)
+    fireEvent.click(newTaskButton)
+
+    await waitFor(() => expect(screen.getByTestId('variables').textContent).toContain('default a'))
+    await waitFor(() => expect(draftStore.get(project.id)?.variables).toEqual({ prompt: 'default a' }))
+
+    await act(async () => {
+      pendingLookup.resolve(cachedDraft)
+      await pendingLookup.promise
+    })
+    expect(screen.getByTestId('variables').textContent).toContain('default a')
+    expect(draftStore.get(project.id)?.variables).toEqual({ prompt: 'default a' })
+  })
+
+  it('restores matching draft fields from the latest workflow definition', async () => {
+    const latestWorkflow: WorkflowDefinition = {
+      ...workflowA,
+      nodes: workflowA.nodes.map((node) => {
+        if (node.type !== 'start') return node
+        const variables = (node.config as { variables: VariableDefinition[] }).variables
+        return {
+          ...node,
+          config: {
+            variables: [
+              ...variables,
+              {
+                key: 'count',
+                label: 'Count',
+                type: 'number' as const,
+                required: false,
+                defaultValue: 9
+              }
+            ]
+          }
+        }
+      })
+    }
+    const data = bootstrap()
+    data.workflows = [latestWorkflow, workflowB]
+    data.workflowRecords = [record(latestWorkflow), record(workflowB)]
+    const { draftStore } = setupApi({
+      data,
+      drafts: {
+        [project.id]: taskDraft(project.id, workflowA, {
+          prompt: 'keep this',
+          count: 'wrong type'
+        })
+      }
+    })
+
+    const newTaskButton = await renderBootstrappedApp()
+    fireEvent.click(newTaskButton)
+
+    await waitFor(() => expect(screen.getByTestId('variables').textContent).toContain('keep this'))
+    expect(screen.getByTestId('variables').textContent).toContain('9')
+    await waitFor(() => expect(draftStore.get(project.id)?.variables).toEqual({ prompt: 'keep this', count: 9 }))
+  })
+
+  it('flushes the active draft before the main process closes the window', async () => {
+    const { api, draftStore, listeners } = setupApi({ drafts: {} })
+    const newTaskButton = await renderBootstrappedApp()
+    fireEvent.click(newTaskButton)
+    await waitFor(() => expect(draftStore.get(project.id)?.variables).toEqual({ prompt: 'default a' }))
+    const callsBeforeEdit = api.saveTaskDraft.mock.calls.length
+    fireEvent.click(screen.getByRole('button', { name: '修改变量' }))
+
+    expect(api.saveTaskDraft).toHaveBeenCalledTimes(callsBeforeEdit)
+
+    act(() => listeners.prepareToClose?.())
+
+    await waitFor(() => expect(api.rendererReadyToClose).toHaveBeenCalledOnce())
+    expect(api.saveTaskDraft.mock.calls.at(-1)?.[0]).toBe(project.id)
+    expect(api.saveTaskDraft.mock.calls.at(-1)?.[1].variables).toEqual({ prompt: 'edited prompt' })
+    expect(draftStore.get(project.id)?.variables).toEqual({ prompt: 'edited prompt' })
+  })
+
+  it('debounces consecutive variable edits into one draft save', async () => {
+    const { api } = setupApi({ drafts: {} })
+    const newTaskButton = await renderBootstrappedApp()
+    fireEvent.click(newTaskButton)
+    await waitFor(() => expect(api.saveTaskDraft).toHaveBeenCalled())
+    const callsBeforeEdit = api.saveTaskDraft.mock.calls.length
+
+    fireEvent.click(screen.getByRole('button', { name: '修改变量' }))
+    fireEvent.click(screen.getByRole('button', { name: '修改变量' }))
+    fireEvent.click(screen.getByRole('button', { name: '修改变量' }))
+
+    expect(api.saveTaskDraft).toHaveBeenCalledTimes(callsBeforeEdit)
+    await new Promise((resolve) => setTimeout(resolve, 350))
+    await waitFor(() => expect(api.saveTaskDraft).toHaveBeenCalledTimes(callsBeforeEdit + 1))
+    expect(api.saveTaskDraft.mock.calls.at(-1)?.[1].variables).toEqual({ prompt: 'edited prompt' })
+  })
+
   it('keeps an unstarted draft out of the task list and adds it after a successful launch', async () => {
-    const { api, listeners } = setupApi()
+    const { api, listeners } = setupApi({ drafts: {} })
     let startedTask: TaskRecord | null = null
     api.startWorkflow.mockImplementation((request: WorkflowRuntimeStartOptions) => {
       const now = '2026-08-05T00:00:00.000Z'
@@ -1019,11 +1243,13 @@ describe('App task workflow selection', () => {
 
     expect(screen.queryByTestId('draft-task')).toBeNull()
     expect(screen.queryByRole('button', { name: '加载 已发起任务' })).toBeNull()
+    await waitFor(() => expect(api.saveTaskDraft).toHaveBeenCalled())
 
     fireEvent.click(screen.getByRole('button', { name: '运行' }))
 
     const startedTaskButton = await screen.findByRole('button', { name: '加载 已发起任务' })
     expect(startedTaskButton.getAttribute('data-task-status')).toBe('running')
+    await waitFor(() => expect(api.deleteTaskDraft).toHaveBeenCalledWith(project.id))
 
     const waitingTask: TaskRecord = { ...startedTask!, status: 'waiting-input' }
     act(() => listeners.workflowState?.({
@@ -1039,6 +1265,72 @@ describe('App task workflow selection', () => {
     fireEvent.click(screen.getByRole('button', { name: '重命名 已发起任务' }))
     await waitFor(() => expect(screen.getByTitle('手动名称')).toBeTruthy())
     expect(api.updateTaskTitle).toHaveBeenCalledWith(waitingTask.id, '手动名称')
+  })
+
+  it('deletes a launched draft even when its runtime state arrives after task navigation', async () => {
+    const existingTask = taskRecords(project, 1, 'Existing')[0]
+    const data = bootstrap([existingTask])
+    const { api } = setupApi({ data, drafts: {} })
+    const pendingStart = deferred<WorkflowRuntimeState>()
+    api.startWorkflow.mockReturnValueOnce(pendingStart.promise)
+    const newTaskButton = await renderBootstrappedApp()
+    fireEvent.click(newTaskButton)
+    await waitFor(() => expect(api.saveTaskDraft).toHaveBeenCalled())
+
+    fireEvent.click(screen.getByRole('button', { name: '运行' }))
+    await waitFor(() => expect(api.startWorkflow).toHaveBeenCalledOnce())
+    const request = api.startWorkflow.mock.calls[0][0]
+    fireEvent.click(screen.getByRole('button', { name: `加载 ${existingTask.title}` }))
+    await waitFor(() => expect(api.restoreWorkflowState).toHaveBeenCalledWith(existingTask.id))
+
+    const now = '2026-08-05T00:00:00.000Z'
+    const launchedTask: TaskRecord = {
+      id: request.taskId,
+      project_id: request.projectId,
+      title: '后台启动任务',
+      status: 'running',
+      created_at: now,
+      updated_at: now
+    }
+    await act(async () => {
+      pendingStart.resolve(runtimeState(request.taskId, request.workflow, launchedTask))
+      await pendingStart.promise
+    })
+
+    await waitFor(() => expect(api.deleteTaskDraft).toHaveBeenCalledWith(project.id))
+    expect(screen.getByRole('button', { name: `加载 ${existingTask.title}` })).toBeTruthy()
+  })
+
+  it('keeps a newer draft when an earlier launch finishes late', async () => {
+    const { api, draftStore } = setupApi({ drafts: {} })
+    const pendingStart = deferred<WorkflowRuntimeState>()
+    api.startWorkflow.mockReturnValueOnce(pendingStart.promise)
+    const newTaskButton = await renderBootstrappedApp()
+    fireEvent.click(newTaskButton)
+    await waitFor(() => expect(api.saveTaskDraft).toHaveBeenCalled())
+
+    fireEvent.click(screen.getByRole('button', { name: '运行' }))
+    await waitFor(() => expect(api.startWorkflow).toHaveBeenCalledOnce())
+    const request = api.startWorkflow.mock.calls[0][0]
+    fireEvent.click(newTaskButton)
+    await waitFor(() => expect(api.saveTaskDraft.mock.calls.at(-1)?.[2]).toBe(true))
+
+    const now = '2026-08-05T00:00:00.000Z'
+    const launchedTask: TaskRecord = {
+      id: request.taskId,
+      project_id: request.projectId,
+      title: '迟到的任务',
+      status: 'running',
+      created_at: now,
+      updated_at: now
+    }
+    await act(async () => {
+      pendingStart.resolve(runtimeState(request.taskId, request.workflow, launchedTask))
+      await pendingStart.promise
+    })
+
+    expect(api.deleteTaskDraft).not.toHaveBeenCalled()
+    expect(draftStore.get(project.id)?.variables).toEqual({ prompt: 'default a' })
   })
 
   it('keeps Stop workflow available while running and waiting for input', async () => {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -50,6 +50,7 @@ import {
   type WorkflowDefinition,
   type WorkflowNode,
   duplicateWorkflowDefinition,
+  validateUserVariableKey,
   validateWorkflow
 } from '../shared/workflow'
 import type {
@@ -57,6 +58,7 @@ import type {
   WorkflowRuntimeNodeRun,
   WorkflowRuntimeState
 } from '../shared/workflowRuntime'
+import { TASK_DRAFT_VERSION } from '../shared/taskDraft'
 import type { TerminalRetryMode } from '../shared/terminalSession'
 import {
   DEFAULT_ASSISTANT_CONFIG,
@@ -115,6 +117,8 @@ import { TerminalScrollGroup } from './components/TerminalScrollGroup'
 import type {
   Bootstrap,
   ProjectRecord,
+  TaskDraftPayload,
+  TaskDraftRecord,
   TaskRecord,
   WorkflowRecord,
   WorkflowSaveResult
@@ -270,6 +274,17 @@ const DESIGNER_NODE_GROUPS: Array<{ labelKey: TranslationKey; types: WorkflowNod
 ]
 
 const TASK_BATCH_SIZE = 10
+const DRAFT_SAVE_DEBOUNCE_MS = 300
+
+type ScheduledDraftSave = {
+  payload: TaskDraftPayload
+  timer: ReturnType<typeof setTimeout>
+}
+
+type PendingDraftLaunch = {
+  contentVersion: number
+  projectId: string
+}
 
 export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
   const { t } = useTranslation()
@@ -335,6 +350,9 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
   const [parallelZoomNodeId, setParallelZoomNodeId] = useState<string | null>(null)
   const [executionOrder, setExecutionOrder] = useState<string[]>([])
   const activeTaskIdRef = useRef(activeTaskId)
+  const activeProjectIdRef = useRef(activeProjectId)
+  const workflowRef = useRef(workflow)
+  const variablesRef = useRef(variables)
   const draftStartedRef = useRef(draftStarted)
   const isNewTaskDraftRef = useRef(isNewTaskDraft)
   const runtimeStateRef = useRef(runtimeState)
@@ -347,6 +365,15 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
   const terminalTranscriptLoadsRef = useRef(new Map<string, Promise<void>>())
   const pendingStartupTaskRef = useRef<{ projectId: string; taskId: string } | null>(null)
   const rememberedWorkspaceKeyRef = useRef('')
+  const draftContentVersionsRef = useRef(new Map<string, number>())
+  const draftRevisionsRef = useRef(new Map<string, number>())
+  const draftSaveQueuesRef = useRef(new Map<string, Promise<void>>())
+  const scheduledDraftSavesRef = useRef(new Map<string, ScheduledDraftSave>())
+  const pendingDraftLaunchesRef = useRef(new Map<string, PendingDraftLaunch>())
+  const draftLoadRequestRef = useRef(0)
+  const pendingDraftLoadProjectRef = useRef<string | null>(null)
+  const draftFlushPromiseRef = useRef<Promise<void> | null>(null)
+  const rendererPreparingToCloseRef = useRef(false)
   const manualFocusRef = useRef(false)
   const designerDirtyRef = useRef(designerDirty)
   const designerOpenRef = useRef(designerOpen)
@@ -358,6 +385,9 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
   designerOpenRef.current = designerOpen
   editingWorkflowIdRef.current = editingWorkflow?.id ?? null
   workflowIdRef.current = workflow.id
+  activeProjectIdRef.current = activeProjectId
+  workflowRef.current = workflow
+  variablesRef.current = variables
   draftStartedRef.current = draftStarted
   isNewTaskDraftRef.current = isNewTaskDraft
   runtimeStateRef.current = runtimeState
@@ -463,6 +493,7 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
         : t('project:addFolderPrompt')
   function updateWorkspaceWorkflow(nextWorkflow: WorkflowDefinition) {
     workflowIdRef.current = nextWorkflow.id
+    workflowRef.current = nextWorkflow
     setWorkflow(nextWorkflow)
   }
 
@@ -473,6 +504,12 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
         ? current
         : (nextWorkflow.nodes[0]?.id ?? '')
     ))
+    if (isNewTaskDraftRef.current && activeProjectIdRef.current) {
+      const nextVariables = restoreDraftVariables(nextWorkflow, variablesRef.current)
+      variablesRef.current = nextVariables
+      setVariables(nextVariables)
+      void persistDraftSnapshot(activeProjectIdRef.current, nextWorkflow, nextVariables)
+    }
   }
 
   function applyWorkflowCatalog(records: WorkflowRecord[]): WorkflowDefinition[] {
@@ -514,6 +551,168 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
     pendingWorkflowIdRef.current = workflowId
     setPendingWorkflowId(workflowId)
     if (workflowId === null) setIsConfirmingWorkflowChange(false)
+  }
+
+  function createDraftPayload(
+    projectId: string,
+    nextWorkflow: WorkflowDefinition,
+    nextVariables: Record<string, VariableValue>
+  ): TaskDraftPayload {
+    const revision = (draftRevisionsRef.current.get(projectId) ?? 0) + 1
+    draftRevisionsRef.current.set(projectId, revision)
+    return {
+      version: TASK_DRAFT_VERSION,
+      workflow: nextWorkflow,
+      variables: { ...nextVariables },
+      revision
+    }
+  }
+
+  function markDraftContentChanged(projectId: string): number {
+    const version = (draftContentVersionsRef.current.get(projectId) ?? 0) + 1
+    draftContentVersionsRef.current.set(projectId, version)
+    return version
+  }
+
+  function enqueueDraftSnapshot(
+    projectId: string,
+    payload: TaskDraftPayload,
+    overwrite = false
+  ): Promise<void> {
+    const saveDraft = window.cliLoom?.saveTaskDraft
+    if (!saveDraft) return Promise.resolve()
+
+    const previous = draftSaveQueuesRef.current.get(projectId) ?? Promise.resolve()
+    const operation = previous.catch(() => undefined).then(async () => {
+      try {
+        const saved = overwrite
+          ? await saveDraft(projectId, payload, true) as TaskDraftRecord | undefined
+          : await saveDraft(projectId, payload) as TaskDraftRecord | undefined
+        if (saved && saved.projectId === projectId) {
+          const currentRevision = draftRevisionsRef.current.get(projectId) ?? 0
+          draftRevisionsRef.current.set(projectId, Math.max(currentRevision, saved.revision))
+        }
+      } catch (error) {
+        handleError(error, 'saveTaskDraft')
+      }
+    })
+    const tracked = operation.finally(() => {
+      if (draftSaveQueuesRef.current.get(projectId) === tracked) {
+        draftSaveQueuesRef.current.delete(projectId)
+      }
+    })
+    draftSaveQueuesRef.current.set(projectId, tracked)
+    return tracked
+  }
+
+  function cancelScheduledDraftSave(projectId: string): TaskDraftPayload | null {
+    const scheduled = scheduledDraftSavesRef.current.get(projectId)
+    if (!scheduled) return null
+    clearTimeout(scheduled.timer)
+    scheduledDraftSavesRef.current.delete(projectId)
+    return scheduled.payload
+  }
+
+  function scheduleDraftSnapshot(
+    projectId: string,
+    nextWorkflow: WorkflowDefinition,
+    nextVariables: Record<string, VariableValue>
+  ): void {
+    if (!window.cliLoom?.saveTaskDraft) return
+
+    markDraftContentChanged(projectId)
+    const payload = createDraftPayload(projectId, nextWorkflow, nextVariables)
+    cancelScheduledDraftSave(projectId)
+    let scheduled!: ScheduledDraftSave
+    const timer = setTimeout(() => {
+      if (scheduledDraftSavesRef.current.get(projectId) !== scheduled) return
+      scheduledDraftSavesRef.current.delete(projectId)
+      void enqueueDraftSnapshot(projectId, payload)
+    }, DRAFT_SAVE_DEBOUNCE_MS)
+    scheduled = { payload, timer }
+    scheduledDraftSavesRef.current.set(projectId, scheduled)
+  }
+
+  function flushScheduledDraftSaves(): Promise<void> {
+    const scheduled = [...scheduledDraftSavesRef.current.entries()]
+    scheduledDraftSavesRef.current.clear()
+    for (const [, item] of scheduled) clearTimeout(item.timer)
+    return Promise.all(scheduled.map(([projectId, item]) => (
+      enqueueDraftSnapshot(projectId, item.payload)
+    ))).then(() => undefined)
+  }
+
+  function persistDraftSnapshot(
+    projectId: string,
+    nextWorkflow: WorkflowDefinition,
+    nextVariables: Record<string, VariableValue>,
+    options: { contentChanged?: boolean; overwrite?: boolean } = {}
+  ): Promise<void> {
+    if (options.contentChanged !== false) markDraftContentChanged(projectId)
+    if (!window.cliLoom?.saveTaskDraft) return Promise.resolve()
+    cancelScheduledDraftSave(projectId)
+    return enqueueDraftSnapshot(
+      projectId,
+      createDraftPayload(projectId, nextWorkflow, nextVariables),
+      options.overwrite
+    )
+  }
+
+  function deletePersistedDraft(projectId: string): Promise<void> {
+    cancelScheduledDraftSave(projectId)
+    const deleteDraft = window.cliLoom?.deleteTaskDraft
+    if (!deleteDraft) {
+      draftRevisionsRef.current.delete(projectId)
+      return Promise.resolve()
+    }
+
+    const previous = draftSaveQueuesRef.current.get(projectId) ?? Promise.resolve()
+    const operation = previous.catch(() => undefined).then(async () => {
+      try {
+        await deleteDraft(projectId)
+        draftRevisionsRef.current.delete(projectId)
+      } catch (error) {
+        handleError(error, 'deleteTaskDraft')
+      }
+    })
+    const tracked = operation.finally(() => {
+      if (draftSaveQueuesRef.current.get(projectId) === tracked) {
+        draftSaveQueuesRef.current.delete(projectId)
+      }
+    })
+    draftSaveQueuesRef.current.set(projectId, tracked)
+    return tracked
+  }
+
+  function flushActiveDraft(): Promise<void> {
+    const projectId = activeProjectIdRef.current
+    if (!projectId || !isNewTaskDraftRef.current) return Promise.resolve()
+    return persistDraftSnapshot(projectId, workflowRef.current, variablesRef.current, {
+      contentChanged: false
+    })
+  }
+
+  async function flushDraftOperations(): Promise<void> {
+    const pendingFlush = draftFlushPromiseRef.current
+    if (pendingFlush) return pendingFlush
+
+    const operation = (async () => {
+      await flushActiveDraft()
+      while (
+        scheduledDraftSavesRef.current.size > 0 ||
+        draftSaveQueuesRef.current.size > 0
+      ) {
+        await flushScheduledDraftSaves()
+        const pending = [...draftSaveQueuesRef.current.values()]
+        await Promise.all(pending.map((item) => item.catch(() => undefined)))
+      }
+    })()
+    draftFlushPromiseRef.current = operation
+    const clearPendingFlush = () => {
+      if (draftFlushPromiseRef.current === operation) draftFlushPromiseRef.current = null
+    }
+    void operation.then(clearPendingFlush, clearPendingFlush)
+    return operation
   }
 
   function currentWorkspaceUsesTaskSnapshot(): boolean {
@@ -567,6 +766,17 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
         options.moveTaskToFront ?? true
       ))
     }
+    const pendingDraftLaunch = pendingDraftLaunchesRef.current.get(state.taskId)
+    if (
+      state.task &&
+      pendingDraftLaunch?.projectId === state.projectId
+    ) {
+      pendingDraftLaunchesRef.current.delete(state.taskId)
+      const currentContentVersion = draftContentVersionsRef.current.get(state.projectId) ?? 0
+      if (currentContentVersion === pendingDraftLaunch.contentVersion) {
+        void deletePersistedDraft(state.projectId)
+      }
+    }
     if (state.taskId !== activeTaskIdRef.current) return
     activeTaskPersistedRef.current = true
     updateRuntimeState(state)
@@ -586,6 +796,7 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
       setFocusedParallelSplitNodeId(nextActiveSplitNodeId)
       setNodeDetailZoomTarget(null)
     }
+    variablesRef.current = state.variables
     setVariables(state.variables)
     setNodeRuns(state.nodeRuns)
     setExecutionOrder(state.executionOrder)
@@ -652,19 +863,35 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
       startingWorkflowTaskIdRef.current === activeTaskId
     ) return
     const taskId = activeTaskId
+    const projectId = activeProject.id
+    const workflowToStart = workflow
+    const variablesToStart = { ...variablesRef.current }
+    const startNodeId = selectedNode.id
+    const startsNewTaskDraft = isNewTaskDraftRef.current
     updateStartingWorkflowTaskId(taskId)
     updatePendingWorkflowId(null)
     manualFocusRef.current = false
+    let pendingDraftLaunchRegistered = false
     try {
+      if (startsNewTaskDraft) {
+        const draftFlush = flushActiveDraft()
+        const contentVersion = draftContentVersionsRef.current.get(projectId) ?? 0
+        await draftFlush
+        pendingDraftLaunchesRef.current.set(taskId, { contentVersion, projectId })
+        pendingDraftLaunchRegistered = true
+      }
       const state = (await window.cliLoom?.startWorkflow({
         taskId,
-        projectId: activeProject.id,
-        workflow,
-        variables,
-        startNodeId: selectedNode.id
+        projectId,
+        workflow: workflowToStart,
+        variables: variablesToStart,
+        startNodeId
       })) as WorkflowRuntimeState | undefined
-      if (state) applyRuntimeState(state)
+      if (state) {
+        applyRuntimeState(state)
+      }
     } catch (error) {
+      if (pendingDraftLaunchRegistered) pendingDraftLaunchesRef.current.delete(taskId)
       handleError(error, 'startWorkflow')
     } finally {
       if (startingWorkflowTaskIdRef.current === taskId) {
@@ -839,17 +1066,26 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
       pendingStartupTaskRef.current = rememberedProject && data.lastOpenedWorkspace?.taskId
         ? { projectId: rememberedProject.id, taskId: data.lastOpenedWorkspace.taskId }
         : null
+      draftContentVersionsRef.current.clear()
+      draftRevisionsRef.current.clear()
+      for (const item of scheduledDraftSavesRef.current.values()) clearTimeout(item.timer)
+      scheduledDraftSavesRef.current.clear()
+      pendingDraftLaunchesRef.current.clear()
+      pendingDraftLoadProjectRef.current = null
       activeTaskPersistedRef.current = false
       updateNewTaskDraft(false)
       updatePendingWorkflowId(null)
       updateRuntimeState(null)
+      activeProjectIdRef.current = initialProject?.id ?? null
       setActiveProjectId(initialProject?.id ?? null)
       const initialWorkflow = data.workflows.find((item) => item.id === initialProject?.default_workflow_id)
         ?? data.workflows[0]
         ?? emptyWorkflow
       updateWorkspaceWorkflow(initialWorkflow)
       setSelectedNodeId(initialWorkflow.nodes[0]?.id ?? '')
-      setVariables(getDefaultVariables(initialWorkflow))
+      const initialVariables = getDefaultVariables(initialWorkflow)
+      variablesRef.current = initialVariables
+      setVariables(initialVariables)
     }).catch((error: unknown) => handleError(error, 'bootstrap'))
     return () => {
       cancelled = true
@@ -1133,12 +1369,60 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
     return () => removeState?.()
   }, [])
 
+  useEffect(() => {
+    const flushDraftBeforeUnload = () => {
+      if (rendererPreparingToCloseRef.current) return
+      void flushDraftOperations()
+    }
+    window.addEventListener('beforeunload', flushDraftBeforeUnload)
+    const removePrepareToClose = window.cliLoom?.onPrepareToClose?.(() => {
+      rendererPreparingToCloseRef.current = true
+      void flushDraftOperations().then(() => {
+        try {
+          window.cliLoom?.rendererReadyToClose?.()
+        } catch {
+          // The main process will use its bounded timeout if the renderer is
+          // already shutting down and cannot send the acknowledgement.
+        }
+      }, () => {
+        // A failed persistence operation must not block a normal application
+        // close; the main process also has a bounded acknowledgement timeout.
+        try {
+          window.cliLoom?.rendererReadyToClose?.()
+        } catch {
+          // See the timeout comment above.
+        }
+      })
+    })
+    return () => {
+      window.removeEventListener('beforeunload', flushDraftBeforeUnload)
+      removePrepareToClose?.()
+      for (const item of scheduledDraftSavesRef.current.values()) {
+        clearTimeout(item.timer)
+      }
+      scheduledDraftSavesRef.current.clear()
+    }
+  }, [])
+
   async function chooseFolder() {
     try {
       const project = (await window.cliLoom?.chooseAndAddProject()) as ProjectRecord | null
       if (!project) return
+      const requestId = draftLoadRequestRef.current + 1
+      draftLoadRequestRef.current = requestId
+      pendingStartupTaskRef.current = null
+      pendingDraftLoadProjectRef.current = null
+      await flushActiveDraft()
+      if (draftLoadRequestRef.current !== requestId) return
       const nextProjects = (await window.cliLoom?.listProjects()) as ProjectRecord[]
+      if (draftLoadRequestRef.current !== requestId) return
       setProjects(nextProjects)
+      // The folder picker also returns an existing project when the selected
+      // path is already registered. Keep the current editor in place in that
+      // case; switching away and back is the explicit navigation action that
+      // should reset the transient workspace.
+      if (project.id === activeProjectIdRef.current) return
+      activeProjectIdRef.current = project.id
       setActiveProjectId(project.id)
       setTasks([])
       resetTaskWorkspaceForProject(project, { draftStarted: false })
@@ -1150,11 +1434,17 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
 
   async function deleteActiveProject(project: ProjectRecord) {
     try {
+      if (project.id === activeProjectIdRef.current) {
+        draftLoadRequestRef.current += 1
+        pendingDraftLoadProjectRef.current = null
+        await flushActiveDraft()
+      }
       await window.cliLoom?.deleteProject(project.id)
       const nextProjects = (await window.cliLoom?.listProjects()) as ProjectRecord[]
       const nextActiveProjectId = getNextActiveProjectIdAfterDelete({ projects: nextProjects, deletedProjectId: project.id })
       const nextProject = nextProjects.find((item) => item.id === nextActiveProjectId) ?? null
       setProjects(nextProjects)
+      activeProjectIdRef.current = nextActiveProjectId
       setActiveProjectId(nextActiveProjectId)
       setTasks([])
       resetTaskWorkspaceForProject(nextProject, { draftStarted: false })
@@ -1222,20 +1512,63 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
     }
   }
 
+  function restoreDraftVariables(
+    nextWorkflow: WorkflowDefinition,
+    cachedVariables: Record<string, VariableValue>
+  ): Record<string, VariableValue> {
+    const defaults = getDefaultVariables(nextWorkflow)
+    const startNode = nextWorkflow.nodes.find((node) => node.type === 'start')
+    const definitions = startNode ? getCurrentInputVariables(startNode) : []
+    const definitionByKey = new Map(definitions.map((definition) => [definition.key, definition]))
+    const restored: Record<string, VariableValue> = {}
+
+    for (const [key, defaultValue] of Object.entries(defaults)) {
+      if (validateUserVariableKey(key)) continue
+      const definition = definitionByKey.get(key)
+      const cachedValue = cachedVariables[key]
+      if (!definition || !Object.prototype.hasOwnProperty.call(cachedVariables, key)) {
+        Object.defineProperty(restored, key, {
+          configurable: true,
+          enumerable: true,
+          value: defaultValue,
+          writable: true
+        })
+        continue
+      }
+
+      const compatible = definition.type === 'number'
+        ? typeof cachedValue === 'number' && Number.isFinite(cachedValue)
+        : typeof cachedValue === 'string'
+      Object.defineProperty(restored, key, {
+        configurable: true,
+        enumerable: true,
+        value: compatible ? cachedValue : defaultValue,
+        writable: true
+      })
+    }
+    return restored
+  }
+
   function resetTaskWorkspaceWithWorkflow(
     nextWorkflow: WorkflowDefinition,
-    options: { draftStarted: boolean; isNewTaskDraft?: boolean }
+    options: {
+      draftStarted: boolean
+      isNewTaskDraft?: boolean
+      variables?: Record<string, VariableValue>
+    }
   ) {
     taskLoadRequestRef.current += 1
     updateWorkspaceWorkflow(nextWorkflow)
     setSelectedNodeId(nextWorkflow.nodes[0]?.id ?? '')
-    setVariables(getDefaultVariables(nextWorkflow))
+    const nextVariables = options.variables ?? getDefaultVariables(nextWorkflow)
+    variablesRef.current = nextVariables
+    setVariables(nextVariables)
     setNodeRuns({})
     setBranchRuns({})
     setSessions([])
     setExecutionOrder([])
     updateRuntimeState(null)
-    const nextTaskId = `draft-${Date.now()}`
+    const nextTaskId = `draft-${Date.now()}-${crypto.randomUUID()}`
     setActiveTaskId(nextTaskId)
     activeTaskIdRef.current = nextTaskId
     activeTaskPersistedRef.current = false
@@ -1253,7 +1586,11 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
 
   function resetTaskWorkspaceForProject(
     project: ProjectRecord | null,
-    options: { draftStarted: boolean; isNewTaskDraft?: boolean }
+    options: {
+      draftStarted: boolean
+      isNewTaskDraft?: boolean
+      variables?: Record<string, VariableValue>
+    }
   ) {
     const nextWorkflow = project
       ? (availableWorkflows.find((item) => item.id === project.default_workflow_id) ?? availableWorkflows[0] ?? emptyWorkflow)
@@ -1261,11 +1598,109 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
     resetTaskWorkspaceWithWorkflow(nextWorkflow, options)
   }
 
-  function startNewTask() {
+  function createFreshProjectDraft(project: ProjectRecord): void {
+    resetTaskWorkspaceForProject(project, { draftStarted: true, isNewTaskDraft: true })
+    rememberWorkspace(project.id, null)
+    void persistDraftSnapshot(project.id, workflowRef.current, variablesRef.current, { overwrite: true })
+  }
+
+  async function startNewTask(): Promise<void> {
     if (!canStartNewTask({ hasActiveProject: Boolean(activeProject) }) || availableWorkflows.length === 0) return
     if (!activeProject) return
-    resetTaskWorkspaceForProject(activeProject, { draftStarted: true, isNewTaskDraft: true })
-    rememberWorkspace(activeProject.id, null)
+
+    const project = activeProject
+    // An explicit New task action takes precedence over the deferred restore
+    // of the last persisted task during application bootstrap.
+    pendingStartupTaskRef.current = null
+    const requestId = draftLoadRequestRef.current + 1
+    draftLoadRequestRef.current = requestId
+
+    // Clicking New task while already editing a draft explicitly replaces it
+    // with a fresh project-default draft, as requested by the product rule.
+    if (isNewTaskDraftRef.current && activeProjectIdRef.current === project.id) {
+      createFreshProjectDraft(project)
+      return
+    }
+
+    // Treat a second click while the first draft lookup is still pending as an
+    // explicit request for a fresh draft as well.
+    if (pendingDraftLoadProjectRef.current === project.id) {
+      pendingDraftLoadProjectRef.current = null
+      createFreshProjectDraft(project)
+      return
+    }
+
+    const getDraft = window.cliLoom?.getTaskDraft
+    if (getDraft) pendingDraftLoadProjectRef.current = project.id
+
+    const pendingDraftOperation = draftSaveQueuesRef.current.get(project.id)
+    if (pendingDraftOperation) {
+      await pendingDraftOperation.catch(() => undefined)
+      if (
+        draftLoadRequestRef.current !== requestId ||
+        activeProjectIdRef.current !== project.id
+      ) return
+    }
+
+    let draft: TaskDraftRecord | null = null
+    if (getDraft) {
+      try {
+        draft = await getDraft(project.id)
+      } catch (error) {
+        if (pendingDraftLoadProjectRef.current === project.id) {
+          pendingDraftLoadProjectRef.current = null
+        }
+        if (
+          draftLoadRequestRef.current !== requestId ||
+          activeProjectIdRef.current !== project.id
+        ) return
+        handleError(error, 'getTaskDraft')
+        return
+      }
+    }
+
+    if (
+      draftLoadRequestRef.current !== requestId ||
+      activeProjectIdRef.current !== project.id
+    ) {
+      if (pendingDraftLoadProjectRef.current === project.id) {
+        pendingDraftLoadProjectRef.current = null
+      }
+      return
+    }
+
+    if (pendingDraftLoadProjectRef.current === project.id) {
+      pendingDraftLoadProjectRef.current = null
+    }
+
+    // Treat a mismatched response as an empty draft. The project ID is part of
+    // the persisted record so a stale or misrouted IPC response can never be
+    // applied to the currently selected project.
+    if (draft && draft.projectId !== project.id) draft = null
+
+    if (!draft) {
+      createFreshProjectDraft(project)
+      return
+    }
+
+    const latestWorkflow = availableWorkflowsRef.current.find((item) => item.id === draft.workflow.id)
+      ?? availableWorkflowsRef.current.find((item) => item.id === project.default_workflow_id)
+      ?? availableWorkflowsRef.current[0]
+      ?? emptyWorkflow
+    const restoredVariables = restoreDraftVariables(latestWorkflow, draft.variables)
+    draftRevisionsRef.current.set(project.id, draft.revision)
+    resetTaskWorkspaceWithWorkflow(latestWorkflow, {
+      draftStarted: true,
+      isNewTaskDraft: true,
+      variables: restoredVariables
+    })
+    rememberWorkspace(project.id, null)
+
+    const workflowChanged = JSON.stringify(latestWorkflow) !== JSON.stringify(draft.workflow)
+    const variablesChanged = JSON.stringify(restoredVariables) !== JSON.stringify(draft.variables)
+    if (workflowChanged || variablesChanged) {
+      void persistDraftSnapshot(project.id, latestWorkflow, restoredVariables)
+    }
   }
 
   function applyDraftWorkflow(nextWorkflow: WorkflowDefinition) {
@@ -1275,6 +1710,7 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
       isNewTaskDraft: true
     })
     rememberWorkspace(activeProject.id, null)
+    void persistDraftSnapshot(activeProject.id, nextWorkflow, variablesRef.current)
   }
 
   function requestDraftWorkflowChange(workflowId: string) {
@@ -1340,6 +1776,14 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
   }
 
   async function selectProject(project: ProjectRecord) {
+    if (project.id === activeProjectIdRef.current) return
+    const requestId = draftLoadRequestRef.current + 1
+    draftLoadRequestRef.current = requestId
+    pendingStartupTaskRef.current = null
+    pendingDraftLoadProjectRef.current = null
+    await flushActiveDraft()
+    if (draftLoadRequestRef.current !== requestId) return
+    activeProjectIdRef.current = project.id
     setActiveProjectId(project.id)
     setTasks([])
     resetTaskWorkspaceForProject(project, { draftStarted: false })
@@ -2316,8 +2760,13 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
   )
 
   function setVariable(key: string, value: VariableValue) {
-    setVariables((current) => ({ ...current, [key]: value }))
+    const nextVariables = { ...variablesRef.current, [key]: value }
+    variablesRef.current = nextVariables
+    setVariables(nextVariables)
     updateDraftStarted(true)
+    if (isNewTaskDraftRef.current && activeProjectIdRef.current) {
+      scheduleDraftSnapshot(activeProjectIdRef.current, workflowRef.current, nextVariables)
+    }
   }
 
   function setBranchVariable(branchId: string, key: string, value: VariableValue) {
@@ -2338,7 +2787,16 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
     window.cliLoom?.writeProcess(sessionId, input)
   }
 
-  function loadTask(task: TaskRecord) {
+  async function loadTask(task: TaskRecord): Promise<void> {
+    const navigationRequestId = draftLoadRequestRef.current + 1
+    draftLoadRequestRef.current = navigationRequestId
+    pendingDraftLoadProjectRef.current = null
+    await flushActiveDraft()
+    if (
+      draftLoadRequestRef.current !== navigationRequestId ||
+      activeProjectIdRef.current !== task.project_id
+    ) return
+
     const requestId = taskLoadRequestRef.current + 1
     taskLoadRequestRef.current = requestId
     setActiveTaskId(task.id)
@@ -2370,7 +2828,9 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
           workflowId?: string
           executionOrder?: string[]
         }
-        setVariables(context.variables ?? {})
+        const restoredVariables = context.variables ?? {}
+        variablesRef.current = restoredVariables
+        setVariables(restoredVariables)
         const restoredRuns = context.nodeRuns ?? {}
         setNodeRuns(restoredRuns)
         setBranchRuns(context.branchRuns ?? {})
@@ -2383,6 +2843,7 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
         setViewMode('focus')
       } catch {
         if (!isCurrentTaskLoad()) return
+        variablesRef.current = {}
         setVariables({})
         setNodeRuns({})
         setBranchRuns({})

--- a/src/renderer/appTypes.ts
+++ b/src/renderer/appTypes.ts
@@ -4,6 +4,7 @@ import type { AppSettingsSnapshot } from '../shared/appSettings'
 import type { TerminalSession } from './utils'
 import type { ShellSnapshot } from '../shared/shell'
 import type { WorkflowRuntimeStatus } from '../shared/workflowRuntime'
+export type { TaskDraftPayload, TaskDraftRecord } from '../shared/taskDraft'
 
 export type ProjectRecord = {
   id: string

--- a/src/shared/i18n/locales/en.ts
+++ b/src/shared/i18n/locales/en.ts
@@ -195,7 +195,8 @@ export default {
       invalidWorkspace: 'The recently opened project and task are invalid',
       taskNotFound: 'Task not found or does not belong to this project',
       taskTitleInvalid: 'Task name must be a string',
-      taskTitleEmpty: 'Task name must not be empty'
+      taskTitleEmpty: 'Task name must not be empty',
+      taskDraftInvalid: 'The task draft is invalid'
     },
     workflowConfig: {
       cancelled: 'The operation was cancelled by the user',

--- a/src/shared/i18n/locales/zh.ts
+++ b/src/shared/i18n/locales/zh.ts
@@ -195,7 +195,8 @@ export default {
       invalidWorkspace: '最近打开的项目和任务无效',
       taskNotFound: '任务不存在或不属于该项目',
       taskTitleInvalid: '任务名称必须是字符串',
-      taskTitleEmpty: '任务名称不能为空'
+      taskTitleEmpty: '任务名称不能为空',
+      taskDraftInvalid: '新建任务草稿无效'
     },
     workflowConfig: {
       cancelled: '用户取消了操作',

--- a/src/shared/taskDraft.ts
+++ b/src/shared/taskDraft.ts
@@ -1,0 +1,100 @@
+import { AppError } from './appError'
+import type { VariableValue, WorkflowDefinition } from './workflow'
+import { parseWorkflowDefinitionStructure } from './workflow'
+
+export const TASK_DRAFT_VERSION = 1 as const
+export const MAX_TASK_DRAFT_VARIABLES = 1_000
+export const MAX_TASK_DRAFT_VALUE_LENGTH = 100_000
+
+export type TaskDraftPayload = {
+  version: typeof TASK_DRAFT_VERSION
+  workflow: WorkflowDefinition
+  variables: Record<string, VariableValue>
+  revision: number
+}
+
+export type TaskDraftRecord = TaskDraftPayload & {
+  projectId: string
+  createdAt: string
+  updatedAt: string
+}
+
+/**
+ * Parse the renderer-facing draft payload at the privileged process boundary.
+ * Drafts intentionally use the structural workflow parser so a snapshot can
+ * still be displayed if its catalog entry was removed or is temporarily
+ * incomplete while the user decides how to replace it.
+ */
+export function parseTaskDraftPayload(value: unknown): TaskDraftPayload {
+  if (!isRecord(value)) {
+    throw invalidTaskDraft('Task draft must be an object')
+  }
+
+  if (value.version !== TASK_DRAFT_VERSION) {
+    throw invalidTaskDraft('Task draft version is unsupported')
+  }
+
+  const workflow = parseWorkflowDefinitionStructure(value.workflow)
+  const variables = parseTaskDraftVariables(value.variables)
+  const revision = parseTaskDraftRevision(value.revision)
+
+  return {
+    version: TASK_DRAFT_VERSION,
+    workflow,
+    variables,
+    revision
+  }
+}
+
+export function parseTaskDraftVariables(value: unknown): Record<string, VariableValue> {
+  if (!isRecord(value)) {
+    throw invalidTaskDraft('Task draft variables must be an object')
+  }
+
+  const entries = Object.entries(value)
+  if (entries.length > MAX_TASK_DRAFT_VARIABLES) {
+    throw invalidTaskDraft('Task draft contains too many variables')
+  }
+
+  const variables: Record<string, VariableValue> = {}
+  for (const [key, item] of entries) {
+    if (!key || key.length > 512 || key.includes('\0')) {
+      throw invalidTaskDraft('Task draft contains an invalid variable key')
+    }
+    if (!isTaskDraftVariableValue(item)) {
+      throw invalidTaskDraft(`Task draft variable ${key} has an invalid value`)
+    }
+    Object.defineProperty(variables, key, {
+      configurable: true,
+      enumerable: true,
+      value: item,
+      writable: true
+    })
+  }
+  return variables
+}
+
+export function parseTaskDraftRevision(value: unknown): number {
+  if (!Number.isSafeInteger(value) || (value as number) < 1) {
+    throw invalidTaskDraft('Task draft revision must be a positive integer')
+  }
+  return value as number
+}
+
+function isTaskDraftVariableValue(value: unknown): value is VariableValue {
+  if (value === null || typeof value === 'boolean') return true
+  if (typeof value === 'number') return Number.isFinite(value)
+  return typeof value === 'string' && value.length <= MAX_TASK_DRAFT_VALUE_LENGTH && !value.includes('\0')
+}
+
+function invalidTaskDraft(message: string): AppError {
+  return new AppError({
+    code: 'TASK_DRAFT_INVALID',
+    message,
+    i18nKey: 'errors:database.taskDraftInvalid'
+  })
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}


### PR DESCRIPTION
Add a per-project task_drafts table (schema v2 with v1 migration),
validated draft payload parsing in shared code, tasks:draft:* IPC and
preload APIs, debounced renderer draft save/restore, and a
flush-before-quit handshake so unsaved draft edits survive app close.
