### PR TITLE
feat(drafts): restore project drafts automatically after switching projects

### DIFF
--- a/src/renderer/App.test.tsx
+++ b/src/renderer/App.test.tsx
@@ -234,6 +234,8 @@ vi.mock('./components/ProjectRail', async () => {
   const React = await import('react')
   return {
     ProjectRail: ({
+      onAddProject,
+      onDeleteProject,
       onOpenDesigner,
       onRenameProject,
       onSelectProject,
@@ -246,6 +248,8 @@ vi.mock('./components/ProjectRail', async () => {
       onInstallUpdate,
       onOpenUpdateRelease
     }: {
+      onAddProject: () => void
+      onDeleteProject: (project: ProjectRecord) => Promise<void>
       onOpenDesigner: () => void
       onRenameProject: (project: ProjectRecord, name: string) => Promise<void>
       onSelectProject: (project: ProjectRecord) => void
@@ -270,8 +274,16 @@ vi.mock('./components/ProjectRail', async () => {
         React.createElement('button', {
           onClick: () => void onRenameProject(item, '  Renamed project  '),
           type: 'button'
-        }, `重命名项目 ${item.name}`)
+        }, `重命名项目 ${item.name}`),
+        React.createElement('button', {
+          onClick: () => void onDeleteProject(item),
+          type: 'button'
+        }, `删除项目 ${item.name}`)
       )),
+      React.createElement('button', {
+        onClick: onAddProject,
+        type: 'button'
+      }, '添加项目文件夹'),
       React.createElement('button', {
         onClick: onOpenDesigner,
         type: 'button'
@@ -700,6 +712,9 @@ function setupApi(options: {
   const api = {
     bootstrap: vi.fn().mockResolvedValue(data),
     listTasks: vi.fn().mockResolvedValue(data.tasks),
+    listProjects: vi.fn().mockResolvedValue(data.projects),
+    chooseAndAddProject: vi.fn().mockResolvedValue(null),
+    deleteProject: vi.fn().mockResolvedValue(undefined),
     listWorkflows: vi.fn(() => Promise.resolve(workflowRecords)),
     restoreWorkflowState: vi.fn().mockResolvedValue(options.restore ?? null),
     getTaskContext: vi.fn().mockResolvedValue('{}'),
@@ -1051,18 +1066,25 @@ describe('App task workflow selection', () => {
     expect((await screen.findByLabelText('Select workflow')).getAttribute('title')).toBe('流程 A')
   })
 
-  it('restores a project draft only when New task is clicked', async () => {
-    const cachedDraft = taskDraft(project.id, workflowA, { prompt: 'cached prompt' }, 7)
-    const { api } = setupApi({ drafts: { [project.id]: cachedDraft } })
-    const newTaskButton = await renderBootstrappedApp()
+  it('automatically restores a project draft after switching projects', async () => {
+    const data = bootstrap()
+    data.projects = [project, otherProject]
+    const cachedDraft = taskDraft(otherProject.id, workflowB, { prompt: 'cached prompt' }, 7)
+    const { api } = setupApi({ data, drafts: { [otherProject.id]: cachedDraft } })
+    await renderBootstrappedApp()
 
     expect(screen.getByTestId('variables').textContent).toContain('default a')
     expect(api.getTaskDraft).not.toHaveBeenCalled()
 
-    fireEvent.click(newTaskButton)
+    fireEvent.click(screen.getByRole('button', { name: '切换项目 Other Project' }))
+
+    await waitFor(() => expect(api.getTaskDraft).toHaveBeenCalledWith(otherProject.id))
+    await waitFor(() => expect(screen.getByTestId('variables').textContent).toContain('cached prompt'))
+
+    fireEvent.click(screen.getByRole('button', { name: '切换项目 Project' }))
 
     await waitFor(() => expect(api.getTaskDraft).toHaveBeenCalledWith(project.id))
-    await waitFor(() => expect(screen.getByTestId('variables').textContent).toContain('cached prompt'))
+    await waitFor(() => expect(screen.getByTestId('variables').textContent).toContain('default a'))
   })
 
   it('keeps drafts scoped to a project while switching projects', async () => {
@@ -1074,20 +1096,135 @@ describe('App task workflow selection', () => {
     })
 
     await renderBootstrappedApp()
-    fireEvent.click(screen.getByRole('button', { name: '新建任务' }))
-    await waitFor(() => expect(screen.getByTestId('variables').textContent).toContain('project one'))
 
     fireEvent.click(screen.getByRole('button', { name: '切换项目 Other Project' }))
     await waitFor(() => expect(api.listTasks).toHaveBeenCalledWith(otherProject.id))
+    await waitFor(() => expect(api.getTaskDraft).toHaveBeenCalledWith(otherProject.id))
+    await waitFor(() => expect(screen.getByTestId('variables').textContent).toContain('default b'))
     expect(api.getTaskDraft).toHaveBeenCalledTimes(1)
 
     fireEvent.click(screen.getByRole('button', { name: '切换项目 Project' }))
-    await waitFor(() => expect(api.listTasks).toHaveBeenCalledWith(project.id))
-    expect(api.getTaskDraft).toHaveBeenCalledTimes(1)
-
-    fireEvent.click(screen.getByRole('button', { name: '新建任务' }))
     await waitFor(() => expect(api.getTaskDraft).toHaveBeenCalledTimes(2))
     await waitFor(() => expect(screen.getByTestId('variables').textContent).toContain('project one'))
+  })
+
+  it('ignores a stale draft lookup when the user switches projects again before it resolves', async () => {
+    const data = bootstrap()
+    data.projects = [project, otherProject]
+    const cachedDraft = taskDraft(otherProject.id, workflowB, { prompt: 'other draft' }, 5)
+    const { api } = setupApi({ data, drafts: { [otherProject.id]: cachedDraft } })
+    const pendingLookup = deferred<TaskDraftRecord | null>()
+    api.getTaskDraft.mockReturnValueOnce(pendingLookup.promise)
+    await renderBootstrappedApp()
+
+    fireEvent.click(screen.getByRole('button', { name: '切换项目 Other Project' }))
+    await waitFor(() => expect(api.getTaskDraft).toHaveBeenCalledWith(otherProject.id))
+    fireEvent.click(screen.getByRole('button', { name: '切换项目 Project' }))
+    await waitFor(() => expect(api.getTaskDraft).toHaveBeenCalledTimes(2))
+
+    await act(async () => {
+      pendingLookup.resolve(cachedDraft)
+      await pendingLookup.promise
+    })
+
+    expect(screen.getByTestId('variables').textContent).toContain('default a')
+  })
+
+  it('treats New task as a fresh-draft request when a stale lookup cleared a newer pending marker', async () => {
+    const data = bootstrap()
+    data.projects = [project, otherProject]
+    const cachedDraft = taskDraft(otherProject.id, workflowB, { prompt: 'other draft' }, 5)
+    const { api, draftStore } = setupApi({ data, drafts: { [otherProject.id]: cachedDraft } })
+    const staleLookup = deferred<TaskDraftRecord | null>()
+    const activeLookup = deferred<TaskDraftRecord | null>()
+    const otherLookups = [staleLookup, activeLookup]
+    api.getTaskDraft.mockImplementation((projectId: string) => (
+      projectId === otherProject.id && otherLookups.length > 0
+        ? otherLookups.shift()!.promise
+        : Promise.resolve(draftStore.get(projectId) ?? null)
+    ))
+    const newTaskButton = await renderBootstrappedApp()
+
+    fireEvent.click(screen.getByRole('button', { name: '切换项目 Other Project' }))
+    await waitFor(() => expect(api.getTaskDraft).toHaveBeenCalledWith(otherProject.id))
+    fireEvent.click(screen.getByRole('button', { name: '切换项目 Project' }))
+    await waitFor(() => expect(api.getTaskDraft).toHaveBeenCalledTimes(2))
+    fireEvent.click(screen.getByRole('button', { name: '切换项目 Other Project' }))
+    await waitFor(() => expect(api.getTaskDraft).toHaveBeenCalledTimes(3))
+
+    await act(async () => {
+      staleLookup.resolve(cachedDraft)
+      await staleLookup.promise
+    })
+
+    // The second lookup for the same project is still pending, so New task
+    // must immediately create a fresh draft instead of restoring the cache.
+    fireEvent.click(newTaskButton)
+    await waitFor(() => expect(screen.getByTestId('variables').textContent).toContain('default b'))
+    await waitFor(() => expect(draftStore.get(otherProject.id)?.variables).toEqual({ prompt: 'default b' }))
+
+    await act(async () => {
+      activeLookup.resolve(cachedDraft)
+      await activeLookup.promise
+    })
+    expect(screen.getByTestId('variables').textContent).toContain('default b')
+    expect(draftStore.get(otherProject.id)?.variables).toEqual({ prompt: 'default b' })
+  })
+
+  it('restores the draft when the folder picker switches to an already registered project', async () => {
+    const data = bootstrap()
+    data.projects = [project, otherProject]
+    const { api } = setupApi({
+      data,
+      drafts: { [otherProject.id]: taskDraft(otherProject.id, workflowB, { prompt: 'cached prompt' }) }
+    })
+    api.chooseAndAddProject.mockResolvedValue(otherProject)
+    await renderBootstrappedApp()
+
+    fireEvent.click(screen.getByRole('button', { name: '添加项目文件夹' }))
+
+    await waitFor(() => expect(api.getTaskDraft).toHaveBeenCalledWith(otherProject.id))
+    await waitFor(() => expect(screen.getByTestId('variables').textContent).toContain('cached prompt'))
+  })
+
+  it('restores the draft of the fallback project after the active project is deleted', async () => {
+    const data = bootstrap()
+    data.projects = [project, otherProject]
+    const { api } = setupApi({
+      data,
+      drafts: { [otherProject.id]: taskDraft(otherProject.id, workflowB, { prompt: 'cached prompt' }) }
+    })
+    api.listProjects.mockResolvedValue([otherProject])
+    await renderBootstrappedApp()
+
+    fireEvent.click(screen.getByRole('button', { name: '删除项目 Project' }))
+
+    await waitFor(() => expect(api.deleteProject).toHaveBeenCalledWith(project.id))
+    await waitFor(() => expect(api.getTaskDraft).toHaveBeenCalledWith(otherProject.id))
+    await waitFor(() => expect(screen.getByTestId('variables').textContent).toContain('cached prompt'))
+  })
+
+  it('keeps the neutral workspace and reports the error when the draft lookup fails after switching', async () => {
+    const data = bootstrap()
+    data.projects = [project, otherProject]
+    const { api } = setupApi({ data, drafts: {} })
+    api.getTaskDraft.mockRejectedValueOnce(new Error('draft store unavailable'))
+    const appErrors: string[] = []
+    const onAppError = (event: Event) => {
+      appErrors.push((event as CustomEvent<{ text: string }>).detail.text)
+    }
+    window.addEventListener('app:error', onAppError)
+    try {
+      await renderBootstrappedApp()
+
+      fireEvent.click(screen.getByRole('button', { name: '切换项目 Other Project' }))
+
+      await waitFor(() => expect(api.getTaskDraft).toHaveBeenCalledWith(otherProject.id))
+      await waitFor(() => expect(appErrors.some((text) => text.includes('getTaskDraft'))).toBe(true))
+      expect(screen.getByTestId('variables').textContent).toContain('default b')
+    } finally {
+      window.removeEventListener('app:error', onAppError)
+    }
   })
 
   it('flushes a debounced draft edit before switching projects', async () => {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -286,6 +286,13 @@ type PendingDraftLaunch = {
   projectId: string
 }
 
+type DraftLookupOutcome = 'restored' | 'missing' | 'aborted' | 'error'
+
+type PendingDraftLoad = {
+  projectId: string
+  requestId: number
+}
+
 export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
   const { t } = useTranslation()
   const [bootstrap, setBootstrap] = useState<Bootstrap>(fallbackBootstrap)
@@ -371,7 +378,7 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
   const scheduledDraftSavesRef = useRef(new Map<string, ScheduledDraftSave>())
   const pendingDraftLaunchesRef = useRef(new Map<string, PendingDraftLaunch>())
   const draftLoadRequestRef = useRef(0)
-  const pendingDraftLoadProjectRef = useRef<string | null>(null)
+  const pendingDraftLoadRef = useRef<PendingDraftLoad | null>(null)
   const draftFlushPromiseRef = useRef<Promise<void> | null>(null)
   const rendererPreparingToCloseRef = useRef(false)
   const manualFocusRef = useRef(false)
@@ -1071,7 +1078,7 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
       for (const item of scheduledDraftSavesRef.current.values()) clearTimeout(item.timer)
       scheduledDraftSavesRef.current.clear()
       pendingDraftLaunchesRef.current.clear()
-      pendingDraftLoadProjectRef.current = null
+      pendingDraftLoadRef.current = null
       activeTaskPersistedRef.current = false
       updateNewTaskDraft(false)
       updatePendingWorkflowId(null)
@@ -1411,7 +1418,7 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
       const requestId = draftLoadRequestRef.current + 1
       draftLoadRequestRef.current = requestId
       pendingStartupTaskRef.current = null
-      pendingDraftLoadProjectRef.current = null
+      pendingDraftLoadRef.current = null
       await flushActiveDraft()
       if (draftLoadRequestRef.current !== requestId) return
       const nextProjects = (await window.cliLoom?.listProjects()) as ProjectRecord[]
@@ -1427,6 +1434,9 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
       setTasks([])
       resetTaskWorkspaceForProject(project, { draftStarted: false })
       rememberWorkspace(project.id, null)
+      // Landing on the project through the folder picker is a project switch
+      // as well, so restore its draft like the rail navigation does.
+      await loadPersistedDraft(project, requestId)
     } catch (error) {
       handleError(error, 'chooseFolder')
     }
@@ -1434,9 +1444,11 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
 
   async function deleteActiveProject(project: ProjectRecord) {
     try {
+      let switchRequestId: number | null = null
       if (project.id === activeProjectIdRef.current) {
-        draftLoadRequestRef.current += 1
-        pendingDraftLoadProjectRef.current = null
+        switchRequestId = draftLoadRequestRef.current + 1
+        draftLoadRequestRef.current = switchRequestId
+        pendingDraftLoadRef.current = null
         await flushActiveDraft()
       }
       await window.cliLoom?.deleteProject(project.id)
@@ -1449,6 +1461,11 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
       setTasks([])
       resetTaskWorkspaceForProject(nextProject, { draftStarted: false })
       rememberWorkspace(nextProject?.id ?? null, null)
+      // Falling back to a neighboring project is a project switch too, so
+      // restore its draft like an explicit navigation would.
+      if (switchRequestId !== null && nextProject) {
+        await loadPersistedDraft(nextProject, switchRequestId)
+      }
     } catch (error) {
       handleError(error, 'deleteActiveProject')
     }
@@ -1604,6 +1621,80 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
     void persistDraftSnapshot(project.id, workflowRef.current, variablesRef.current, { overwrite: true })
   }
 
+  // Loads the persisted draft for a project and applies it to the workspace.
+  // Shared by the explicit New task action and the automatic restore that
+  // follows switching projects. Aborts without touching the workspace when a
+  // newer navigation request has taken over.
+  async function loadPersistedDraft(project: ProjectRecord, requestId: number): Promise<DraftLookupOutcome> {
+    const getDraft = window.cliLoom?.getTaskDraft
+    if (getDraft) pendingDraftLoadRef.current = { projectId: project.id, requestId }
+
+    const isCurrentRequest = () => (
+      draftLoadRequestRef.current === requestId && activeProjectIdRef.current === project.id
+    )
+    // Only the request that owns the pending marker may clear it, so a stale
+    // lookup for the same project cannot unset a newer pending lookup.
+    const clearPendingLoad = () => {
+      if (pendingDraftLoadRef.current?.requestId === requestId) {
+        pendingDraftLoadRef.current = null
+      }
+    }
+
+    const pendingDraftOperation = draftSaveQueuesRef.current.get(project.id)
+    if (pendingDraftOperation) {
+      await pendingDraftOperation.catch(() => undefined)
+      if (!isCurrentRequest()) {
+        clearPendingLoad()
+        return 'aborted'
+      }
+    }
+
+    let draft: TaskDraftRecord | null = null
+    if (getDraft) {
+      try {
+        draft = await getDraft(project.id)
+      } catch (error) {
+        clearPendingLoad()
+        if (!isCurrentRequest()) return 'aborted'
+        handleError(error, 'getTaskDraft')
+        return 'error'
+      }
+    }
+
+    if (!isCurrentRequest()) {
+      clearPendingLoad()
+      return 'aborted'
+    }
+    clearPendingLoad()
+
+    // Treat a mismatched response as an empty draft. The project ID is part of
+    // the persisted record so a stale or misrouted IPC response can never be
+    // applied to the currently selected project.
+    if (draft && draft.projectId !== project.id) draft = null
+
+    if (!draft) return 'missing'
+
+    const latestWorkflow = availableWorkflowsRef.current.find((item) => item.id === draft.workflow.id)
+      ?? availableWorkflowsRef.current.find((item) => item.id === project.default_workflow_id)
+      ?? availableWorkflowsRef.current[0]
+      ?? emptyWorkflow
+    const restoredVariables = restoreDraftVariables(latestWorkflow, draft.variables)
+    draftRevisionsRef.current.set(project.id, draft.revision)
+    resetTaskWorkspaceWithWorkflow(latestWorkflow, {
+      draftStarted: true,
+      isNewTaskDraft: true,
+      variables: restoredVariables
+    })
+    rememberWorkspace(project.id, null)
+
+    const workflowChanged = JSON.stringify(latestWorkflow) !== JSON.stringify(draft.workflow)
+    const variablesChanged = JSON.stringify(restoredVariables) !== JSON.stringify(draft.variables)
+    if (workflowChanged || variablesChanged) {
+      void persistDraftSnapshot(project.id, latestWorkflow, restoredVariables)
+    }
+    return 'restored'
+  }
+
   async function startNewTask(): Promise<void> {
     if (!canStartNewTask({ hasActiveProject: Boolean(activeProject) }) || availableWorkflows.length === 0) return
     if (!activeProject) return
@@ -1624,82 +1715,27 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
 
     // Treat a second click while the first draft lookup is still pending as an
     // explicit request for a fresh draft as well.
-    if (pendingDraftLoadProjectRef.current === project.id) {
-      pendingDraftLoadProjectRef.current = null
+    if (pendingDraftLoadRef.current?.projectId === project.id) {
+      pendingDraftLoadRef.current = null
       createFreshProjectDraft(project)
       return
     }
 
-    const getDraft = window.cliLoom?.getTaskDraft
-    if (getDraft) pendingDraftLoadProjectRef.current = project.id
+    // Without a draft bridge there is nothing to look up, so keep this path
+    // synchronous and create the fresh draft immediately.
+    if (!window.cliLoom?.getTaskDraft && !draftSaveQueuesRef.current.get(project.id)) {
+      createFreshProjectDraft(project)
+      return
+    }
 
-    const pendingDraftOperation = draftSaveQueuesRef.current.get(project.id)
-    if (pendingDraftOperation) {
-      await pendingDraftOperation.catch(() => undefined)
+    const outcome = await loadPersistedDraft(project, requestId)
+    if (outcome === 'missing') {
       if (
-        draftLoadRequestRef.current !== requestId ||
-        activeProjectIdRef.current !== project.id
-      ) return
-    }
-
-    let draft: TaskDraftRecord | null = null
-    if (getDraft) {
-      try {
-        draft = await getDraft(project.id)
-      } catch (error) {
-        if (pendingDraftLoadProjectRef.current === project.id) {
-          pendingDraftLoadProjectRef.current = null
-        }
-        if (
-          draftLoadRequestRef.current !== requestId ||
-          activeProjectIdRef.current !== project.id
-        ) return
-        handleError(error, 'getTaskDraft')
-        return
+        draftLoadRequestRef.current === requestId &&
+        activeProjectIdRef.current === project.id
+      ) {
+        createFreshProjectDraft(project)
       }
-    }
-
-    if (
-      draftLoadRequestRef.current !== requestId ||
-      activeProjectIdRef.current !== project.id
-    ) {
-      if (pendingDraftLoadProjectRef.current === project.id) {
-        pendingDraftLoadProjectRef.current = null
-      }
-      return
-    }
-
-    if (pendingDraftLoadProjectRef.current === project.id) {
-      pendingDraftLoadProjectRef.current = null
-    }
-
-    // Treat a mismatched response as an empty draft. The project ID is part of
-    // the persisted record so a stale or misrouted IPC response can never be
-    // applied to the currently selected project.
-    if (draft && draft.projectId !== project.id) draft = null
-
-    if (!draft) {
-      createFreshProjectDraft(project)
-      return
-    }
-
-    const latestWorkflow = availableWorkflowsRef.current.find((item) => item.id === draft.workflow.id)
-      ?? availableWorkflowsRef.current.find((item) => item.id === project.default_workflow_id)
-      ?? availableWorkflowsRef.current[0]
-      ?? emptyWorkflow
-    const restoredVariables = restoreDraftVariables(latestWorkflow, draft.variables)
-    draftRevisionsRef.current.set(project.id, draft.revision)
-    resetTaskWorkspaceWithWorkflow(latestWorkflow, {
-      draftStarted: true,
-      isNewTaskDraft: true,
-      variables: restoredVariables
-    })
-    rememberWorkspace(project.id, null)
-
-    const workflowChanged = JSON.stringify(latestWorkflow) !== JSON.stringify(draft.workflow)
-    const variablesChanged = JSON.stringify(restoredVariables) !== JSON.stringify(draft.variables)
-    if (workflowChanged || variablesChanged) {
-      void persistDraftSnapshot(project.id, latestWorkflow, restoredVariables)
     }
   }
 
@@ -1780,7 +1816,7 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
     const requestId = draftLoadRequestRef.current + 1
     draftLoadRequestRef.current = requestId
     pendingStartupTaskRef.current = null
-    pendingDraftLoadProjectRef.current = null
+    pendingDraftLoadRef.current = null
     await flushActiveDraft()
     if (draftLoadRequestRef.current !== requestId) return
     activeProjectIdRef.current = project.id
@@ -1788,6 +1824,10 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
     setTasks([])
     resetTaskWorkspaceForProject(project, { draftStarted: false })
     rememberWorkspace(project.id, null)
+    // Switching to a project that has a persisted draft restores it directly
+    // so editing resumes without clicking New task again. Without a draft the
+    // neutral workspace prepared above stays in place.
+    await loadPersistedDraft(project, requestId)
   }
 
   async function setDefaultWorkflow(workflowId: string) {
@@ -2790,7 +2830,7 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
   async function loadTask(task: TaskRecord): Promise<void> {
     const navigationRequestId = draftLoadRequestRef.current + 1
     draftLoadRequestRef.current = navigationRequestId
-    pendingDraftLoadProjectRef.current = null
+    pendingDraftLoadRef.current = null
     await flushActiveDraft()
     if (
       draftLoadRequestRef.current !== navigationRequestId ||


### PR DESCRIPTION
Switching projects via the rail, folder picker, or delete fallback now
restores the target project's persisted draft instead of waiting for a
New task click. The pending draft lookup marker is bound to its request
id so a stale lookup can no longer clear a newer pending lookup.
