### PR TITLE
fix(runtime): keep persisted running state when restoring a live engine

### DIFF
--- a/src/main/runtimePersistence.test.ts
+++ b/src/main/runtimePersistence.test.ts
@@ -373,6 +373,50 @@ describe('runtime persistence', () => {
     expect(workflowRun.status).toBe('interrupted')
   })
 
+  it('preserves in-flight running node runs without a persisted session id when reconciliation is disabled', () => {
+    const db = createDb()
+    persistState(db, state({
+      nodeRuns: {
+        start: { nodeId: 'start', status: 'completed' },
+        terminal: { nodeId: 'terminal', status: 'running' }
+      }
+    }), 'running')
+    db.prepare(
+      'insert into terminal_sessions (id, task_id, node_id, kind, command, cwd, status, transcript, created_at, updated_at) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
+    ).run(
+      'session-1',
+      'task-1',
+      'terminal',
+      'non-interactive',
+      'sleep 60',
+      '/repo',
+      'running',
+      '',
+      '2026-06-17T00:00:00.000Z',
+      '2026-06-17T00:00:00.000Z'
+    )
+
+    const restored = restoreWorkflowRuntimeState(db, 'task-1', {
+      isTerminalSessionLive: () => true,
+      reconcileRunning: false
+    })
+
+    expect(restored.state?.status).toBe('running')
+    expect(restored.state?.nodeRuns.terminal).toMatchObject({ status: 'running' })
+    expect(restored.terminalSessions[0]).toMatchObject({
+      id: 'session-1',
+      status: 'running'
+    })
+    const task = db.prepare('select status from tasks where id = ?').get('task-1') as { status: string }
+    const workflowRun = db.prepare('select status from workflow_runs where task_id = ?').get('task-1') as { status: string }
+    const nodeRun = db.prepare(
+      'select status from node_runs where run_id = ? and node_id = ?'
+    ).get('task-1', 'terminal') as { status: string }
+    expect(task.status).toBe('running')
+    expect(workflowRun.status).toBe('running')
+    expect(nodeRun.status).toBe('running')
+  })
+
   it('restores stale and just-completed parallel terminal branches as interrupted', () => {
     const db = createDb()
     const parallelWorkflow: WorkflowDefinition = {

--- a/src/main/runtimePersistence.ts
+++ b/src/main/runtimePersistence.ts
@@ -34,6 +34,7 @@ export type RestoreRuntimeOptions = {
   getLiveTerminalTranscript?: (
     session: TerminalSessionRecord
   ) => TerminalTranscriptSnapshot | null
+  reconcileRunning?: boolean
 }
 
 export type RuntimeRestoreResult = {
@@ -186,7 +187,7 @@ export function restoreWorkflowRuntimeState(
 ): RuntimeRestoreResult {
   const terminalSessions = listTerminalSessionMetadataByTask(db, taskId)
   const normalizedSessions = normalizeTerminalSessions(db, terminalSessions, options)
-  reconcileTaskRuntimeState(db, taskId)
+  if (options.reconcileRunning !== false) reconcileTaskRuntimeState(db, taskId)
   const run = db
     .prepare('select * from workflow_runs where task_id = ? order by updated_at desc limit 1')
     .get(taskId) as WorkflowRunRow | undefined

--- a/src/main/workflowRuntimeService.test.ts
+++ b/src/main/workflowRuntimeService.test.ts
@@ -179,6 +179,76 @@ describe('WorkflowRuntimeService restore', () => {
     expect(service.getState('running-task')).toBeNull()
   })
 
+  it('keeps persisted running state intact when restoring a task whose engine is live mid-flight', async () => {
+    const db = createDb()
+    const runningWorkflow: WorkflowDefinition = {
+      id: 'live-running-workflow',
+      name: 'Live running workflow',
+      nodes: [
+        { id: 'start', type: 'start', name: 'Start', config: { variables: [] } },
+        {
+          id: 'terminal',
+          type: 'non-interactive-terminal',
+          name: 'Terminal',
+          config: { command: 'sleep 60', cwd: '/repo', successExitCodes: [0] }
+        },
+        { id: 'end', type: 'end', name: 'End', config: {} }
+      ],
+      edges: [
+        { id: 'start-terminal', from: 'start', to: 'terminal' },
+        { id: 'terminal-end', from: 'terminal', to: 'end' }
+      ]
+    }
+    let resolveTerminal!: (result: WorkflowRuntimeProcessResult) => void
+    const terminalResult = new Promise<WorkflowRuntimeProcessResult>((resolve) => {
+      resolveTerminal = resolve
+    })
+    const killByTask = vi.fn(() => 0)
+    const runner = {
+      run: vi.fn(() => terminalResult),
+      runHook: async () => ({ hookRunId: 'hook-1', stdout: '', stderr: '', exitCode: 0 }),
+      killByTask,
+      hasLiveSession: () => true,
+      getLiveTranscriptSnapshot: () => ({ transcript: 'partial output', cursor: 3 })
+    }
+    const service = new WorkflowRuntimeService(db, runner as never, () => null)
+
+    await service.start({
+      taskId: 'live-running-task',
+      projectId: 'project-1',
+      projectDir: '/repo',
+      workflow: runningWorkflow,
+      variables: {}
+    })
+    await vi.waitFor(() => {
+      expect(runner.run).toHaveBeenCalledWith(expect.objectContaining({ nodeId: 'terminal' }))
+    })
+    killByTask.mockClear()
+
+    const restored = await service.restore('live-running-task')
+
+    expect(killByTask).not.toHaveBeenCalled()
+    expect(restored.state?.status).toBe('running')
+    expect(restored.state?.nodeRuns.terminal.status).toBe('running')
+    expect(service.getState('live-running-task')?.status).toBe('running')
+    const task = db.prepare('select status from tasks where id = ?')
+      .get('live-running-task') as { status: string }
+    const workflowRun = db.prepare('select status from workflow_runs where task_id = ?')
+      .get('live-running-task') as { status: string }
+    const nodeRun = db.prepare('select status from node_runs where run_id = ? and node_id = ?')
+      .get('live-running-task', 'terminal') as { status: string }
+    expect(task.status).toBe('running')
+    expect(workflowRun.status).toBe('running')
+    expect(nodeRun.status).toBe('running')
+
+    resolveTerminal({ sessionId: 'live-session', stdout: 'done', stderr: '', exitCode: 0, status: 'closed' })
+    await vi.waitFor(() => {
+      const completed = db.prepare('select status from tasks where id = ?')
+        .get('live-running-task') as { status: string }
+      expect(completed.status).toBe('completed')
+    })
+  })
+
   it('validates the workflow before creating runtime records', async () => {
     const db = createDb()
     const runner = {

--- a/src/main/workflowRuntimeService.ts
+++ b/src/main/workflowRuntimeService.ts
@@ -313,7 +313,8 @@ export class WorkflowRuntimeService {
           isTerminalSessionLive: (session) => this.processRunner.hasLiveSession(session.id),
           getLiveTerminalTranscript: (session) => (
             this.processRunner.getLiveTranscriptSnapshot(session.id)
-          )
+          ),
+          reconcileRunning: false
         })
       : this.restoreWithoutActiveEngine(taskId)
     if (active) return { ...restored, state: active.getState() }


### PR DESCRIPTION
Reconciling on restore demoted in-flight terminal node runs (persisted
without a session id) to interrupted even while the engine and its PTY
were live, so running tasks showed as interrupted after switching
projects and back. Skip the running-state reconciliation when the task
has an active engine; orphan recovery without an engine is unchanged.
