### PR TITLE
fix(update): render release notes as rich text in update dialog

### DIFF
--- a/src/renderer/App.test.tsx
+++ b/src/renderer/App.test.tsx
@@ -463,6 +463,17 @@ vi.mock('./components/StatusBadge', () => ({
   StatusBadge: () => null
 }))
 
+vi.mock('./components/ReleaseNotesView', async () => {
+  const React = await import('react')
+  return {
+    ReleaseNotesView: ({ markdown }: { markdown: string }) => React.createElement(
+      'div',
+      { 'data-testid': 'release-notes-view' },
+      markdown
+    )
+  }
+})
+
 vi.mock('./components/TerminalScrollGroup', async () => {
   const React = await import('react')
   return {
@@ -902,6 +913,7 @@ describe('App update flow', () => {
     }))
 
     expect(screen.getByRole('heading', { name: 'CLILoom v0.2.0 is available' })).toBeTruthy()
+    expect(screen.getByTestId('release-notes-view').textContent).toBe('<script>plain release note</script>')
     expect(screen.getByText('<script>plain release note</script>')).toBeTruthy()
     fireEvent.click(screen.getByRole('button', { name: 'View update' }))
     await waitFor(() => expect(api.openUpdateRelease).toHaveBeenCalledOnce())

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -110,6 +110,7 @@ import { pruneJoinIncomingEdgeIds } from './designer/joinEdges'
 import { NodeDetailPanel } from './components/NodeDetailPanel'
 import { ParallelBranchGroup } from './components/ParallelBranchGroup'
 import { ProjectRail } from './components/ProjectRail'
+import { ReleaseNotesView } from './components/ReleaseNotesView'
 import { AppearancePanel } from './components/AppearancePanel'
 import { StatusBadge } from './components/StatusBadge'
 import { TaskSidebar } from './components/TaskSidebar'
@@ -2215,8 +2216,8 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
       />
 
       <Dialog open={updateDialogOpen} onOpenChange={setUpdateDialogOpen}>
-        <DialogContent className="sm:max-w-lg">
-          <DialogHeader>
+        <DialogContent className="flex max-h-[calc(100dvh-2rem)] flex-col overflow-hidden sm:max-w-lg">
+          <DialogHeader className="shrink-0">
             <DialogTitle>
               {t(
                 updateState.status === 'downloaded'
@@ -2260,13 +2261,22 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
                 )}
             </DialogDescription>
           </DialogHeader>
-          <section aria-label={t('settings:update.releaseNotes')} className="min-h-0">
-            <h3 className="mb-2 text-sm font-medium">{t('settings:update.releaseNotes')}</h3>
-            <p className="max-h-56 overflow-y-auto whitespace-pre-wrap rounded-md border bg-muted/40 p-3 text-sm text-muted-foreground">
-              {updateState.releaseNotes ?? t('settings:update.noReleaseNotes')}
-            </p>
+          <section
+            aria-label={t('settings:update.releaseNotes')}
+            className="flex min-h-0 flex-1 flex-col"
+          >
+            <h3 className="mb-2 shrink-0 text-sm font-medium">{t('settings:update.releaseNotes')}</h3>
+            <div className="min-h-0 flex-1 overflow-hidden rounded-md border bg-muted/40">
+              {updateState.releaseNotes ? (
+                <ReleaseNotesView markdown={updateState.releaseNotes} />
+              ) : (
+                <p className="h-full overflow-y-auto p-3 text-sm text-muted-foreground">
+                  {t('settings:update.noReleaseNotes')}
+                </p>
+              )}
+            </div>
           </section>
-          <DialogFooter>
+          <DialogFooter className="shrink-0">
             <Button variant="outline" onClick={() => setUpdateDialogOpen(false)}>
               {t('settings:update.later')}
             </Button>

--- a/src/renderer/components/ReleaseNotesView.render.test.tsx
+++ b/src/renderer/components/ReleaseNotesView.render.test.tsx
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, waitFor } from '@testing-library/react'
+import { act } from 'react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { i18n } from '../i18n'
+import { ReleaseNotesView } from './ReleaseNotesView'
+
+const markdownNotes = [
+  'All macOS and Windows assets in this release are currently unsigned.',
+  '',
+  "## What's Changed",
+  '',
+  '* Fix update dialog by @laurentwu in #14',
+  '* **Full Changelog**: https://github.com/laurentwu/CLILoom/compare/v0.1.0...v0.1.1',
+  '',
+  '<script>alert(1)</script>',
+  '',
+  '```bash',
+  'npm run test',
+  '```'
+].join('\n')
+
+const atomHtmlNotes = [
+  '<p dir="auto">All macOS and Windows assets in this release are currently unsigned.</p>',
+  '<h2 dir="auto">What&#39;s Changed</h2>',
+  '<ul dir="auto">',
+  '<li dir="auto">Fix update dialog by @laurentwu in <a class="issue-link js-issue-link" href="https://github.com/laurentwu/CLILoom/pull/14">#14</a></li>',
+  '<li dir="auto"><strong>Full Changelog</strong>: <a href="https://github.com/laurentwu/CLILoom/compare/v0.1.0...v0.1.1">v0.1.0...v0.1.1</a></li>',
+  '</ul>'
+].join('')
+
+function releaseNotesContent(container: HTMLElement): HTMLElement {
+  const content = container.querySelector('.release-notes-content')
+  expect(content).toBeTruthy()
+  return content as HTMLElement
+}
+
+describe('ReleaseNotesView rendering', () => {
+  afterEach(async () => {
+    cleanup()
+    await i18n.changeLanguage('en')
+  })
+
+  it('renders GitHub-style release notes as rich text with inert HTML', async () => {
+    const { container } = render(
+      <div style={{ height: 400 }}>
+        <ReleaseNotesView markdown={markdownNotes} />
+      </div>
+    )
+
+    const content = releaseNotesContent(container)
+    await waitFor(() => expect(content.textContent).toContain("What's Changed"))
+
+    expect(content.getAttribute('contenteditable')).toBe('false')
+    expect(container.querySelector('h2')?.textContent).toContain("What's Changed")
+    expect(container.querySelectorAll('ul li')).toHaveLength(2)
+    expect(container.querySelector('strong')?.textContent).toBe('Full Changelog')
+    expect(container.querySelector('a')?.getAttribute('href')).toBe(
+      'https://github.com/laurentwu/CLILoom/compare/v0.1.0...v0.1.1'
+    )
+    expect(container.querySelector('script')).toBeNull()
+    expect(content.textContent).toContain('<script>alert(1)</script>')
+    expect(container.querySelector('.cm-content')?.textContent).toContain('npm run test')
+  })
+
+  it('renders atom-feed HTML release notes as rich text', async () => {
+    const { container } = render(
+      <div style={{ height: 400 }}>
+        <ReleaseNotesView markdown={atomHtmlNotes} />
+      </div>
+    )
+
+    const content = releaseNotesContent(container)
+    await waitFor(() => expect(content.textContent).toContain("What's Changed"))
+
+    expect(container.querySelector('h2')?.textContent).toContain("What's Changed")
+    expect(container.querySelectorAll('ul li')).toHaveLength(2)
+    expect(container.querySelector('strong')?.textContent).toBe('Full Changelog')
+    const hrefs = Array.from(container.querySelectorAll('a')).map((anchor) => anchor.getAttribute('href'))
+    expect(hrefs).toContain('https://github.com/laurentwu/CLILoom/pull/14')
+    expect(hrefs).toContain('https://github.com/laurentwu/CLILoom/compare/v0.1.0...v0.1.1')
+    expect(content.textContent).not.toContain('<h2')
+    expect(content.textContent).not.toContain('<li')
+    expect(container.querySelector('script')).toBeNull()
+  })
+
+  it('updates the rendered notes when the update state changes', async () => {
+    const { container, rerender } = render(
+      <div style={{ height: 400 }}>
+        <ReleaseNotesView markdown={atomHtmlNotes} />
+      </div>
+    )
+    const content = releaseNotesContent(container)
+    await waitFor(() => expect(content.textContent).toContain("What's Changed"))
+
+    rerender(
+      <div style={{ height: 400 }}>
+        <ReleaseNotesView markdown={'<p dir="auto">Ready to install</p>'} />
+      </div>
+    )
+
+    await waitFor(() => expect(releaseNotesContent(container).textContent).toContain('Ready to install'))
+  })
+
+  it('labels the read-only area with the localized release notes title', async () => {
+    await i18n.changeLanguage('en')
+    const { container, rerender } = render(
+      <div style={{ height: 400 }}>
+        <ReleaseNotesView markdown={markdownNotes} />
+      </div>
+    )
+    const content = await waitFor(() => {
+      const element = container.querySelector<HTMLElement>('[data-lexical-editor]')
+      expect(element).toBeTruthy()
+      return element as HTMLElement
+    })
+
+    expect(content.getAttribute('aria-label')).toBe('Release notes')
+
+    await i18n.changeLanguage('zh')
+    rerender(
+      <div style={{ height: 400 }}>
+        <ReleaseNotesView markdown={markdownNotes} />
+      </div>
+    )
+
+    expect(content.getAttribute('aria-label')).toBe('版本说明')
+  })
+
+  it('prevents rendered links from navigating the Electron page', async () => {
+    const { container } = render(<ReleaseNotesView markdown={markdownNotes} />)
+    const link = await waitFor(() => {
+      const anchor = container.querySelector('a')
+      expect(anchor).toBeTruthy()
+      return anchor as HTMLAnchorElement
+    })
+    const click = new MouseEvent('click', { bubbles: true, cancelable: true })
+
+    act(() => link.dispatchEvent(click))
+
+    expect(click.defaultPrevented).toBe(true)
+  })
+})

--- a/src/renderer/components/ReleaseNotesView.test.tsx
+++ b/src/renderer/components/ReleaseNotesView.test.tsx
@@ -1,0 +1,156 @@
+// @vitest-environment jsdom
+
+import { act } from 'react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { i18n } from '../i18n'
+
+const editorState = vi.hoisted(() => ({
+  lastProps: null as Record<string, unknown> | null,
+  mountCount: 0
+}))
+
+const pluginMocks = vi.hoisted(() => ({
+  codeBlockPlugin: vi.fn((options?: unknown) => ({ name: 'codeBlock', options })),
+  codeMirrorPlugin: vi.fn((options?: unknown) => ({ name: 'codeMirror', options })),
+  headingsPlugin: vi.fn(() => ({ name: 'headings' })),
+  linkPlugin: vi.fn(() => ({ name: 'link' })),
+  listsPlugin: vi.fn(() => ({ name: 'lists' })),
+  quotePlugin: vi.fn(() => ({ name: 'quote' })),
+  tablePlugin: vi.fn(() => ({ name: 'table' })),
+  thematicBreakPlugin: vi.fn(() => ({ name: 'thematicBreak' }))
+}))
+
+const terminalMarkdownPluginMock = vi.hoisted(() => vi.fn(() => ({ name: 'terminalMarkdown' })))
+
+vi.mock('@mdxeditor/editor', async () => {
+  const React = await import('react')
+  const MDXEditor = (props: Record<string, unknown>) => {
+    React.useEffect(() => {
+      editorState.mountCount += 1
+    }, [])
+    editorState.lastProps = props
+    return React.createElement(
+      'div',
+      { 'data-testid': 'mock-mdx-editor' },
+      React.createElement('a', { href: 'https://github.com/laurentwu/CLILoom' }, 'release link'),
+      React.createElement('button', {
+        onClick: () => (props.onError as ((value: { error: string; source: string }) => void) | undefined)?.({
+          error: 'invalid markdown',
+          source: 'raw <broken> notes'
+        }),
+        type: 'button'
+      }, '触发解析错误')
+    )
+  }
+  return { MDXEditor, ...pluginMocks }
+})
+
+vi.mock('../terminalMarkdown', () => ({
+  terminalMarkdownPlugin: terminalMarkdownPluginMock
+}))
+
+import { ReleaseNotesView } from './ReleaseNotesView'
+
+describe('ReleaseNotesView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    editorState.lastProps = null
+    editorState.mountCount = 0
+  })
+
+  afterEach(async () => {
+    cleanup()
+    await i18n.changeLanguage('en')
+  })
+
+  it('renders release notes as read-only markdown without HTML processing', () => {
+    render(<ReleaseNotesView markdown={"## What's Changed"} />)
+
+    expect(screen.getByTestId('mock-mdx-editor')).toBeTruthy()
+    expect(editorState.lastProps).toMatchObject({
+      markdown: "## What's Changed",
+      readOnly: true,
+      spellCheck: false,
+      suppressHtmlProcessing: true,
+      trim: false
+    })
+    expect(terminalMarkdownPluginMock).toHaveBeenCalledOnce()
+    expect(pluginMocks.headingsPlugin).toHaveBeenCalledOnce()
+    expect(pluginMocks.listsPlugin).toHaveBeenCalledOnce()
+    expect(pluginMocks.quotePlugin).toHaveBeenCalledOnce()
+    expect(pluginMocks.thematicBreakPlugin).toHaveBeenCalledOnce()
+    expect(pluginMocks.linkPlugin).toHaveBeenCalledOnce()
+    expect(pluginMocks.tablePlugin).toHaveBeenCalledOnce()
+    expect(pluginMocks.codeBlockPlugin).toHaveBeenCalledWith({ defaultCodeBlockLanguage: '' })
+    expect(pluginMocks.codeMirrorPlugin).toHaveBeenCalledWith(expect.objectContaining({
+      autoLoadLanguageSupport: false
+    }))
+  })
+
+  it('converts atom-feed HTML notes into markdown before rendering', () => {
+    render(<ReleaseNotesView markdown={'<p dir="auto">hello <strong>world</strong></p>'} />)
+
+    expect(editorState.lastProps).toMatchObject({
+      markdown: 'hello **world**'
+    })
+  })
+
+  it('localizes the read-only content area label', async () => {
+    await i18n.changeLanguage('zh')
+    render(<ReleaseNotesView markdown="content" />)
+    const translate = editorState.lastProps?.translation as (
+      key: string,
+      fallback: string,
+      interpolations?: Record<string, string>
+    ) => string
+
+    expect(translate('contentArea.editableMarkdown', 'editable markdown')).toBe('版本说明')
+    expect(translate('unknown', 'Fallback {{value}}', { value: 'label' })).toBe('Fallback label')
+
+    await i18n.changeLanguage('en')
+    expect(translate('contentArea.editableMarkdown', 'editable markdown')).toBe('Release notes')
+  })
+
+  it('remounts the editor when the release notes change', () => {
+    const view = render(<ReleaseNotesView markdown="first" />)
+    expect(editorState.mountCount).toBe(1)
+
+    view.rerender(<ReleaseNotesView markdown="second" />)
+    expect(editorState.mountCount).toBe(2)
+    expect(editorState.lastProps).toMatchObject({ markdown: 'second' })
+  })
+
+  it('prevents release-note links from navigating the Electron page', () => {
+    render(<ReleaseNotesView markdown="[docs](https://example.com)" />)
+    const click = new MouseEvent('click', { bubbles: true, cancelable: true })
+
+    act(() => screen.getByRole('link', { name: 'release link' }).dispatchEvent(click))
+
+    expect(click.defaultPrevented).toBe(true)
+  })
+
+  it('falls back to wrapping plain text when the markdown cannot be parsed', () => {
+    render(<ReleaseNotesView markdown="broken notes" />)
+    fireEvent.click(screen.getByRole('button', { name: '触发解析错误' }))
+
+    const fallback = screen.getByText('raw <broken> notes')
+    expect(fallback.tagName).toBe('P')
+    expect(fallback.className).toContain('whitespace-pre-wrap')
+    expect(fallback.className).toContain('break-words')
+    expect(fallback.className).toContain('[overflow-wrap:anywhere]')
+    expect(screen.queryByTestId('mock-mdx-editor')).toBeNull()
+  })
+
+  it('recovers the rendered view once the markdown changes after a parse failure', () => {
+    const view = render(<ReleaseNotesView markdown="first" />)
+    fireEvent.click(screen.getByRole('button', { name: '触发解析错误' }))
+    expect(screen.getByText('raw <broken> notes')).toBeTruthy()
+
+    view.rerender(<ReleaseNotesView markdown="second" />)
+
+    expect(screen.getByTestId('mock-mdx-editor')).toBeTruthy()
+    expect(screen.queryByText('raw <broken> notes')).toBeNull()
+    expect(editorState.lastProps).toMatchObject({ markdown: 'second' })
+  })
+})

--- a/src/renderer/components/ReleaseNotesView.tsx
+++ b/src/renderer/components/ReleaseNotesView.tsx
@@ -1,0 +1,102 @@
+import { useMemo, useState, type MouseEvent } from 'react'
+import {
+  MDXEditor,
+  codeBlockPlugin,
+  codeMirrorPlugin,
+  headingsPlugin,
+  linkPlugin,
+  listsPlugin,
+  quotePlugin,
+  tablePlugin,
+  thematicBreakPlugin,
+  type Translation
+} from '@mdxeditor/editor'
+import { i18n } from '../i18n'
+import { releaseNotesToMarkdown } from '../releaseNotesMarkdown'
+import { terminalMarkdownPlugin } from '../terminalMarkdown'
+import type { TranslationKey } from '../../shared/i18n/types'
+import '@mdxeditor/editor/style.css'
+
+const editorKeyCatalog: Record<string, TranslationKey> = {
+  'contentArea.editableMarkdown': 'settings:update.releaseNotes'
+}
+
+const translate: Translation = (key, defaultValue, interpolations = {}) => {
+  const catalogKey = editorKeyCatalog[key]
+  if (!catalogKey) {
+    let value = defaultValue
+    for (const [name, replacement] of Object.entries(interpolations)) {
+      value = value.replaceAll(`{{${name}}}`, String(replacement))
+    }
+    return value
+  }
+  return i18n.t(catalogKey, interpolations as Record<string, unknown>)
+}
+
+const codeBlockLanguages = {
+  '': 'Plain Text',
+  bash: 'Bash',
+  css: 'CSS',
+  html: 'HTML',
+  javascript: 'JavaScript',
+  js: 'JavaScript',
+  json: 'JSON',
+  markdown: 'Markdown',
+  md: 'Markdown',
+  shell: 'Shell',
+  sh: 'Shell',
+  tsx: 'TypeScript React',
+  typescript: 'TypeScript',
+  ts: 'TypeScript',
+  yaml: 'YAML',
+  yml: 'YAML'
+}
+
+export function ReleaseNotesView({ markdown }: { markdown: string }) {
+  const [parseFailure, setParseFailure] = useState<{ markdown: string; source: string } | null>(null)
+  const renderedMarkdown = useMemo(() => releaseNotesToMarkdown(markdown), [markdown])
+  const plugins = useMemo(() => [
+    terminalMarkdownPlugin(),
+    headingsPlugin(),
+    listsPlugin(),
+    quotePlugin(),
+    thematicBreakPlugin(),
+    linkPlugin(),
+    tablePlugin(),
+    codeBlockPlugin({ defaultCodeBlockLanguage: '' }),
+    codeMirrorPlugin({ autoLoadLanguageSupport: false, codeBlockLanguages })
+  ], [])
+
+  const failedSource = parseFailure?.markdown === renderedMarkdown ? parseFailure.source : null
+
+  const preventLinkNavigation = (event: MouseEvent<HTMLDivElement>) => {
+    const target = event.target
+    if (target instanceof Element && target.closest('a')) event.preventDefault()
+  }
+
+  if (failedSource !== null) {
+    return (
+      <p className="h-full overflow-y-auto whitespace-pre-wrap break-words [overflow-wrap:anywhere] p-3 text-sm text-muted-foreground">
+        {failedSource}
+      </p>
+    )
+  }
+
+  return (
+    <div className="h-full" onClickCapture={preventLinkNavigation}>
+      <MDXEditor
+        key={renderedMarkdown}
+        className="release-notes-editor mdxeditor-full-height h-full"
+        contentEditableClassName="release-notes-content"
+        markdown={renderedMarkdown}
+        onError={({ source }) => setParseFailure({ markdown: renderedMarkdown, source })}
+        plugins={plugins}
+        readOnly
+        spellCheck={false}
+        suppressHtmlProcessing
+        translation={translate}
+        trim={false}
+      />
+    </div>
+  )
+}

--- a/src/renderer/releaseNotesMarkdown.test.ts
+++ b/src/renderer/releaseNotesMarkdown.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from 'vitest'
+import { releaseNotesToMarkdown } from './releaseNotesMarkdown'
+
+describe('releaseNotesToMarkdown', () => {
+  it('passes plain markdown and text through untouched', () => {
+    const notes = "## What's Changed\n\n- item **bold**\n\n```bash\nnpm run test\n```"
+    expect(releaseNotesToMarkdown(notes)).toBe(notes)
+    expect(releaseNotesToMarkdown('a < b and c > d')).toBe('a < b and c > d')
+    expect(releaseNotesToMarkdown('<script>alert(1)</script>')).toBe('<script>alert(1)</script>')
+  })
+
+  it('converts GitHub atom-feed release notes into markdown', () => {
+    const notes = [
+      '<p dir="auto">All macOS and Windows assets in this release are currently unsigned.</p>',
+      '<h2 dir="auto">What&#39;s Changed</h2>',
+      '<ul dir="auto">',
+      '<li dir="auto">Fix update dialog by @laurentwu in <a class="issue-link js-issue-link" href="https://github.com/laurentwu/CLILoom/pull/14">#14</a></li>',
+      '<li dir="auto"><strong>Full Changelog</strong>: <a href="https://github.com/laurentwu/CLILoom/compare/v0.1.0...v0.1.1">v0.1.0...v0.1.1</a></li>',
+      '</ul>'
+    ].join('')
+    expect(releaseNotesToMarkdown(notes)).toBe(
+      [
+        'All macOS and Windows assets in this release are currently unsigned.',
+        '',
+        "## What's Changed",
+        '',
+        '- Fix update dialog by @laurentwu in [#14](https://github.com/laurentwu/CLILoom/pull/14)',
+        '- **Full Changelog**: [v0.1.0...v0.1.1](https://github.com/laurentwu/CLILoom/compare/v0.1.0...v0.1.1)'
+      ].join('\n')
+    )
+  })
+
+  it('converts headings, ordered lists, quotes, code blocks, and rules', () => {
+    const notes = [
+      '<div class="markdown-body">',
+      '<h3>Fixes</h3>',
+      '<ol><li>first</li><li>second</li></ol>',
+      '<blockquote><p>quoted words</p></blockquote>',
+      '<pre><code class="language-bash">npm run test\n</code></pre>',
+      '<hr>',
+      '</div>'
+    ].join('')
+    expect(releaseNotesToMarkdown(notes)).toBe(
+      [
+        '### Fixes',
+        '',
+        '1. first',
+        '2. second',
+        '',
+        '> quoted words',
+        '',
+        '```bash',
+        'npm run test',
+        '```',
+        '',
+        '---'
+      ].join('\n')
+    )
+  })
+
+  it('escapes markdown syntax in text and keeps unsafe constructs inert', () => {
+    expect(releaseNotesToMarkdown('<p>a*b _c_ [d] `e`</p>')).toBe('a\\*b \\_c\\_ \\[d\\] \\`e\\`')
+    expect(releaseNotesToMarkdown('<p><a href="javascript:alert(1)">click</a></p>')).toBe('click')
+    expect(releaseNotesToMarkdown('<p><img src="https://example.com/pixel.png" alt="logo"></p>')).toBe('logo')
+  })
+})

--- a/src/renderer/releaseNotesMarkdown.ts
+++ b/src/renderer/releaseNotesMarkdown.ts
@@ -1,0 +1,195 @@
+const LEADING_BLOCK_TAG = /^\s*<(?:p|div|section|article|main|h[1-6]|ul|ol|li|blockquote|pre|table|hr|br)\b/i
+
+const HEADING_TAGS: Record<string, number> = {
+  h1: 1,
+  h2: 2,
+  h3: 3,
+  h4: 4,
+  h5: 5,
+  h6: 6
+}
+
+export function releaseNotesToMarkdown(notes: string): string {
+  if (!LEADING_BLOCK_TAG.test(notes)) return notes
+  const body = new DOMParser().parseFromString(notes, 'text/html').body
+  const converted = normalizeBlocks(convertBlocks(body))
+  return converted || notes
+}
+
+function convertBlocks(element: Element): string {
+  let result = ''
+  for (const node of Array.from(element.childNodes)) result += convertNode(node)
+  return result
+}
+
+function convertNode(node: Node): string {
+  if (node.nodeType === Node.TEXT_NODE) return escapeMarkdown(node.textContent ?? '')
+  if (node.nodeType !== Node.ELEMENT_NODE) return ''
+  return convertElement(node as Element)
+}
+
+function convertElement(element: Element): string {
+  const tag = element.tagName.toLowerCase()
+  const headingLevel = HEADING_TAGS[tag]
+  if (headingLevel !== undefined) {
+    const text = inlineContent(element).trim()
+    return text ? `\n\n${'#'.repeat(headingLevel)} ${text}\n\n` : ''
+  }
+  switch (tag) {
+    case 'p': {
+      const text = inlineContent(element).trim()
+      return text ? `\n\n${text}\n\n` : ''
+    }
+    case 'div':
+    case 'section':
+    case 'article':
+    case 'main':
+      return `\n${convertBlocks(element)}\n`
+    case 'br':
+      return '\n'
+    case 'hr':
+      return '\n\n---\n\n'
+    case 'ul':
+    case 'ol':
+      return convertList(element, 0)
+    case 'li': {
+      const text = inlineContent(element).trim()
+      return text ? `\n- ${text}\n` : ''
+    }
+    case 'blockquote': {
+      const content = normalizeBlocks(convertBlocks(element))
+      if (!content) return ''
+      const quoted = content.split('\n').map((line) => (line ? `> ${line}` : '>')).join('\n')
+      return `\n\n${quoted}\n\n`
+    }
+    case 'pre': {
+      const code = element.querySelector('code')
+      const language = /(?:^|\s)language-([\w+-]+)/.exec(code?.className ?? '')?.[1] ?? ''
+      const text = (code?.textContent ?? element.textContent ?? '').replace(/\n+$/, '')
+      return text ? `\n\n\`\`\`${language}\n${text}\n\`\`\`\n\n` : ''
+    }
+    case 'table':
+      return convertTable(element)
+    default:
+      return inlineContent(element)
+  }
+}
+
+function convertList(element: Element, depth: number): string {
+  const ordered = element.tagName.toLowerCase() === 'ol'
+  const indent = '  '.repeat(depth)
+  const lines: string[] = []
+  let index = 1
+  for (const child of Array.from(element.children)) {
+    const tag = child.tagName.toLowerCase()
+    if (tag === 'li') {
+      const marker = ordered ? `${index++}.` : '-'
+      lines.push(`${indent}${marker} ${listItemContent(child, depth)}`)
+    } else if (tag === 'ul' || tag === 'ol') {
+      lines.push(convertList(child, depth + 1))
+    }
+  }
+  return lines.length > 0 ? `\n\n${lines.join('\n')}\n\n` : ''
+}
+
+function listItemContent(item: Element, depth: number): string {
+  let inline = ''
+  const nested: string[] = []
+  for (const node of Array.from(item.childNodes)) {
+    if (node.nodeType === Node.TEXT_NODE) {
+      inline += escapeMarkdown(node.textContent ?? '')
+    } else if (node.nodeType === Node.ELEMENT_NODE) {
+      const element = node as Element
+      const tag = element.tagName.toLowerCase()
+      if (tag === 'ul' || tag === 'ol') nested.push(convertList(element, depth + 1))
+      else inline += inlineElement(element)
+    }
+  }
+  const label = inline.trim().replaceAll('\n', ' ')
+  return nested.length > 0 ? `${label}\n${nested.join('\n')}` : label
+}
+
+function convertTable(table: Element): string {
+  const rows: string[] = []
+  for (const row of Array.from(table.querySelectorAll('tr'))) {
+    const cells = Array.from(row.children)
+      .filter((cell) => {
+        const tag = cell.tagName.toLowerCase()
+        return tag === 'th' || tag === 'td'
+      })
+      .map((cell) => inlineContent(cell).trim().replaceAll('|', '\\|'))
+    if (cells.length > 0) rows.push(cells.join(' | '))
+  }
+  return rows.length > 0 ? `\n\n${rows.join('\n')}\n\n` : ''
+}
+
+function inlineContent(element: Element): string {
+  let result = ''
+  for (const node of Array.from(element.childNodes)) {
+    if (node.nodeType === Node.TEXT_NODE) result += escapeMarkdown(node.textContent ?? '')
+    else if (node.nodeType === Node.ELEMENT_NODE) result += inlineElement(node as Element)
+  }
+  return result
+}
+
+function inlineElement(element: Element): string {
+  const tag = element.tagName.toLowerCase()
+  switch (tag) {
+    case 'strong':
+    case 'b': {
+      const inner = inlineContent(element).trim()
+      return inner ? `**${inner}**` : ''
+    }
+    case 'em':
+    case 'i': {
+      const inner = inlineContent(element).trim()
+      return inner ? `*${inner}*` : ''
+    }
+    case 'del':
+    case 's':
+    case 'strike': {
+      const inner = inlineContent(element).trim()
+      return inner ? `~~${inner}~~` : ''
+    }
+    case 'code': {
+      const text = element.textContent ?? ''
+      if (!text) return ''
+      return text.includes('`') ? '``' + text + '``' : '`' + text + '`'
+    }
+    case 'a': {
+      const label = inlineContent(element).trim()
+      const href = element.getAttribute('href') ?? ''
+      if (!/^(https?:\/\/|mailto:|\/|#)/i.test(href)) return label
+      const safeLabel = label.replaceAll('[', '\\[').replaceAll(']', '\\]')
+      return `[${safeLabel}](${href})`
+    }
+    case 'br':
+      return '\n'
+    case 'img':
+      return element.getAttribute('alt') ?? ''
+    case 'script':
+    case 'style':
+      return element.outerHTML
+    default:
+      return inlineContent(element)
+  }
+}
+
+function escapeMarkdown(value: string): string {
+  return value
+    .replaceAll('\\', '\\\\')
+    .replaceAll('*', '\\*')
+    .replaceAll('_', '\\_')
+    .replaceAll('`', '\\`')
+    .replaceAll('[', '\\[')
+    .replaceAll(']', '\\]')
+}
+
+function normalizeBlocks(value: string): string {
+  return value
+    .split('\n')
+    .map((line) => line.replace(/\s+$/, ''))
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim()
+}

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -798,6 +798,145 @@ body,
   text-underline-offset: 0.2em;
 }
 
+.mdxeditor.release-notes-editor {
+  --accentBase: var(--background);
+  --accentBgSubtle: var(--muted);
+  --accentBg: var(--accent);
+  --accentBgHover: var(--accent);
+  --accentBgActive: var(--secondary);
+  --accentLine: var(--border);
+  --accentBorder: var(--border);
+  --accentBorderHover: var(--ring);
+  --accentSolid: var(--primary);
+  --accentSolidHover: var(--primary);
+  --accentText: var(--foreground);
+  --accentTextContrast: var(--primary-foreground);
+  --basePageBg: var(--background);
+  --baseBase: var(--background);
+  --baseBgSubtle: var(--muted);
+  --baseBg: var(--muted);
+  --baseBgHover: var(--accent);
+  --baseBgActive: var(--secondary);
+  --baseLine: var(--border);
+  --baseBorder: var(--border);
+  --baseBorderHover: var(--ring);
+  --baseSolid: var(--muted-foreground);
+  --baseSolidHover: var(--foreground);
+  --baseText: var(--muted-foreground);
+  --baseTextContrast: var(--foreground);
+  background: transparent;
+  color: var(--foreground);
+}
+
+.release-notes-content {
+  width: 100%;
+  max-width: none;
+  min-height: 100%;
+  padding: 0.75rem;
+  color: var(--foreground);
+  font-family: var(--font-sans);
+  font-size: 0.875rem;
+  line-height: 1.6;
+  overflow-wrap: anywhere;
+}
+
+.release-notes-content h1,
+.release-notes-content h2,
+.release-notes-content h3,
+.release-notes-content h4,
+.release-notes-content h5,
+.release-notes-content h6 {
+  margin-block: 1em 0.4em;
+  color: var(--foreground);
+  font-weight: 600;
+  line-height: 1.25;
+}
+
+.release-notes-content h1 {
+  font-size: 1.125rem;
+}
+
+.release-notes-content h2 {
+  font-size: 1rem;
+}
+
+.release-notes-content h3,
+.release-notes-content h4,
+.release-notes-content h5,
+.release-notes-content h6 {
+  font-size: 0.9375rem;
+}
+
+.release-notes-content p,
+.release-notes-content ul,
+.release-notes-content ol,
+.release-notes-content blockquote,
+.release-notes-content pre,
+.release-notes-content table {
+  margin-block: 0.5rem;
+}
+
+.release-notes-content ul,
+.release-notes-content ol {
+  padding-left: 1.25rem;
+}
+
+.release-notes-content ul {
+  list-style: disc;
+}
+
+.release-notes-content ol {
+  list-style: decimal;
+}
+
+.release-notes-content blockquote {
+  border-left: 3px solid var(--border);
+  padding-left: 0.75rem;
+  color: var(--muted-foreground);
+}
+
+.release-notes-content code {
+  border-radius: 0.25rem;
+  background: var(--muted);
+  padding: 0.1rem 0.3rem;
+  font-family: var(--font-code);
+  font-size: 0.875em;
+}
+
+.release-notes-content pre {
+  overflow-x: auto;
+}
+
+.release-notes-content pre code {
+  background: transparent;
+  padding: 0;
+}
+
+.release-notes-content hr {
+  margin-block: 0.75rem;
+  border: 0;
+  border-top: 1px solid var(--border);
+}
+
+.release-notes-content table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.release-notes-content th,
+.release-notes-content td {
+  border: 1px solid var(--border);
+  padding: 0.3rem 0.5rem;
+  text-align: left;
+}
+
+.release-notes-content a {
+  color: var(--primary);
+  text-decoration: underline;
+  text-underline-offset: 0.2em;
+  cursor: default;
+}
+
 .react-flow__controls {
   overflow: hidden;
   border: 1px solid var(--border);


### PR DESCRIPTION
GitHub serves release notes as rendered HTML through the updater Atom
feed, so the dialog previously showed raw markup source. The notes are
now converted to markdown and rendered by a read-only MDXEditor view
that keeps embedded HTML inert, blocks link navigation, and falls back
to wrapped plain text on parse failures. The dialog is capped at the
viewport height with internal notes scrolling, long URLs wrap instead
of overflowing, and the read-only content area uses a localized label.
