### PR TITLE
fix(renderer): isolate task state per project and flag unread updates

### DIFF
--- a/e2e/task-project-isolation.e2e.ts
+++ b/e2e/task-project-isolation.e2e.ts
@@ -1,0 +1,239 @@
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import {
+  _electron as electron,
+  expect,
+  test,
+  type ElectronApplication,
+  type Page
+} from 'playwright/test'
+import type { ProjectRecord, TaskRecord } from '../src/renderer/appTypes'
+import type { WorkflowDefinition } from '../src/shared/workflow'
+
+type CspViolation = {
+  blockedUri: string
+  directive: string
+}
+
+type WindowWithCspProbe = Window & typeof globalThis & {
+  __cliloomCspViolations?: CspViolation[]
+}
+
+const workflow: WorkflowDefinition = {
+  id: 'e2e-project-isolation',
+  name: 'Project isolation workflow',
+  nodes: [
+    {
+      id: 'start',
+      type: 'start',
+      name: 'Start',
+      config: {
+        variables: [{
+          key: 'title',
+          label: 'Title',
+          type: 'text',
+          required: true
+        }]
+      }
+    },
+    {
+      id: 'input',
+      type: 'input',
+      name: 'Wait for input',
+      config: { variables: [] }
+    },
+    { id: 'end', type: 'end', name: 'End', config: {} }
+  ],
+  edges: [
+    { id: 'start-input', from: 'start', to: 'input' },
+    { id: 'input-end', from: 'input', to: 'end' }
+  ]
+}
+
+const failures: string[] = []
+let appDataDirectory = ''
+let electronApp: ElectronApplication
+let fixtureDirectory = ''
+let mainPage: Page
+let projectADirectory = ''
+let projectBDirectory = ''
+
+test.skip(process.platform !== 'linux', 'The production-entry isolation test runs on Linux')
+
+function monitorPage(page: Page) {
+  page.on('pageerror', (error) => failures.push(`page error: ${error.message}`))
+  page.on('console', (message) => {
+    if (
+      message.type() === 'error' &&
+      /Content Security Policy|Refused to (?:load|execute|apply|connect)/i.test(message.text())
+    ) {
+      failures.push(`console: ${message.text()}`)
+    }
+  })
+}
+
+test.beforeAll(async () => {
+  const projectRoot = path.join(__dirname, '..')
+  appDataDirectory = mkdtempSync(path.join(tmpdir(), 'cliloom-isolation-e2e-data-'))
+  fixtureDirectory = mkdtempSync(path.join(tmpdir(), 'cliloom-isolation-e2e-projects-'))
+  projectADirectory = path.join(fixtureDirectory, 'Project A')
+  projectBDirectory = path.join(fixtureDirectory, 'Project B')
+  mkdirSync(projectADirectory)
+  mkdirSync(projectBDirectory)
+  electronApp = await electron.launch({
+    args: [projectRoot],
+    cwd: projectRoot,
+    env: {
+      ...process.env,
+      VITE_DEV_SERVER_URL: '',
+      XDG_CONFIG_HOME: appDataDirectory
+    }
+  })
+  const context = electronApp.context()
+  await context.addInitScript(() => {
+    const target = window as WindowWithCspProbe
+    target.__cliloomCspViolations = []
+    document.addEventListener('securitypolicyviolation', (event) => {
+      target.__cliloomCspViolations?.push({
+        blockedUri: event.blockedURI,
+        directive: event.effectiveDirective
+      })
+    })
+  })
+  mainPage = await electronApp.firstWindow()
+  monitorPage(mainPage)
+  await mainPage.locator('#root > *').first().waitFor()
+})
+
+test.afterAll(async () => {
+  await electronApp?.close()
+  if (appDataDirectory) rmSync(appDataDirectory, { recursive: true, force: true })
+  if (fixtureDirectory) rmSync(fixtureDirectory, { recursive: true, force: true })
+})
+
+test('isolates background task updates and clears unread after a successful project load', async ({}, testInfo) => {
+  failures.splice(0)
+  await electronApp.evaluate(({ dialog }, directories) => {
+    const state = globalThis as typeof globalThis & {
+      __cliloomDialogDirectories?: string[]
+      __cliloomOriginalShowOpenDialog?: typeof dialog.showOpenDialog
+    }
+    state.__cliloomDialogDirectories = [...directories]
+    state.__cliloomOriginalShowOpenDialog = dialog.showOpenDialog
+    dialog.showOpenDialog = async () => ({
+      canceled: false,
+      filePaths: [state.__cliloomDialogDirectories?.shift() ?? '']
+    })
+  }, [projectADirectory, projectBDirectory])
+
+  const addProject = mainPage.getByRole('button', { name: 'Add project folder' })
+  await addProject.click()
+  await expect(mainPage.getByRole('button', { name: 'Open project Project A' })).toBeVisible()
+  await addProject.click()
+  await expect(mainPage.getByRole('button', { name: 'Open project Project B' })).toBeVisible()
+
+  await electronApp.evaluate(({ dialog }) => {
+    const state = globalThis as typeof globalThis & {
+      __cliloomDialogDirectories?: string[]
+      __cliloomOriginalShowOpenDialog?: typeof dialog.showOpenDialog
+    }
+    if (state.__cliloomOriginalShowOpenDialog) {
+      dialog.showOpenDialog = state.__cliloomOriginalShowOpenDialog
+    }
+    delete state.__cliloomDialogDirectories
+    delete state.__cliloomOriginalShowOpenDialog
+  })
+
+  const projects = await mainPage.evaluate(() => window.cliLoom?.listProjects()) as ProjectRecord[]
+  const projectA = projects.find((project) => project.path === projectADirectory)
+  const projectB = projects.find((project) => project.path === projectBDirectory)
+  expect(projectA).toBeTruthy()
+  expect(projectB).toBeTruthy()
+  if (!projectA || !projectB) throw new Error('E2E projects were not registered')
+
+  await mainPage.evaluate(async (definition) => {
+    if (!window.cliLoom) throw new Error('Missing main preload API')
+    await window.cliLoom.saveWorkflow(definition)
+  }, workflow)
+  await expect(mainPage.getByRole('button', { name: 'New task' })).toBeEnabled()
+
+  const startTask = (taskId: string, projectId: string, title: string) => mainPage.evaluate(
+    async ({ definition, projectId, taskId, title }) => {
+      if (!window.cliLoom) throw new Error('Missing main preload API')
+      await window.cliLoom.startWorkflow({
+        taskId,
+        projectId,
+        workflow: definition,
+        variables: { title },
+        startNodeId: 'start'
+      })
+    },
+    { definition: workflow, projectId, taskId, title }
+  )
+  const listTasks = (projectId: string) => mainPage.evaluate(
+    async (id) => {
+      if (!window.cliLoom) throw new Error('Missing main preload API')
+      return window.cliLoom.listTasks(id)
+    },
+    projectId
+  ) as Promise<TaskRecord[]>
+
+  const taskBId = 'e2e-background-task'
+  await startTask(taskBId, projectB.id, 'B task')
+  await expect.poll(async () => (
+    (await listTasks(projectB.id)).find((task) => task.id === taskBId)?.status
+  )).toBe('waiting-input')
+  await expect(mainPage.locator('.task-sidebar').getByText('B task', { exact: true })).toBeVisible()
+
+  await mainPage.getByRole('button', { name: 'Open project Project A' }).click()
+  await expect(mainPage.locator('.task-sidebar').getByText('Project A', { exact: true })).toBeVisible()
+  const taskAId = 'e2e-current-task'
+  await startTask(taskAId, projectA.id, 'A task')
+  await expect.poll(async () => (
+    (await listTasks(projectA.id)).find((task) => task.id === taskAId)?.status
+  )).toBe('waiting-input')
+  await expect(mainPage.locator('.task-sidebar').getByText('A task', { exact: true })).toBeVisible()
+  const workspaceTitleBefore = await mainPage.locator('.workspace-header__task-title').textContent()
+
+  await mainPage.evaluate(async (taskId) => {
+    if (!window.cliLoom) throw new Error('Missing main preload API')
+    await window.cliLoom.updateWorkflowVariables(taskId, {})
+  }, taskBId)
+  await expect.poll(async () => (
+    (await listTasks(projectB.id)).find((task) => task.id === taskBId)?.status
+  )).toBe('completed')
+
+  const unreadMarker = mainPage.locator(
+    `[data-project-unread-indicator="true"][data-project-id="${projectB.id}"]`
+  )
+  await expect(unreadMarker).toBeVisible()
+  await expect(mainPage.locator('.task-sidebar').getByText('A task', { exact: true })).toBeVisible()
+  await expect(mainPage.locator('.task-sidebar').getByText('B task', { exact: true })).toHaveCount(0)
+  expect(await mainPage.locator('.workspace-header__task-title').textContent()).toBe(workspaceTitleBefore)
+  await testInfo.attach('project-unread-marker-visible', {
+    body: await mainPage.screenshot(),
+    contentType: 'image/png'
+  })
+
+  await mainPage.getByRole('button', {
+    name: 'Open project Project B, unread task status updates'
+  }).click()
+  await expect(mainPage.locator('.task-sidebar').getByText('B task', { exact: true })).toBeVisible()
+  await expect(mainPage.locator('.task-sidebar').getByText('A task', { exact: true })).toHaveCount(0)
+  await expect(mainPage.locator('.task-sidebar').getByText('Completed', { exact: true })).toBeVisible()
+  await expect(unreadMarker).toHaveCount(0)
+
+  await mainPage.getByRole('button', { name: 'Open project Project A' }).click()
+  await expect(mainPage.locator('.task-sidebar').getByText('A task', { exact: true })).toBeVisible()
+  await expect(mainPage.locator('.task-sidebar').getByText('B task', { exact: true })).toHaveCount(0)
+
+  await testInfo.attach('project-unread-marker-cleared', {
+    body: await mainPage.screenshot(),
+    contentType: 'image/png'
+  })
+  expect(await mainPage.evaluate(() => (
+    (window as WindowWithCspProbe).__cliloomCspViolations ?? []
+  ))).toEqual([])
+  expect(failures).toEqual([])
+})

--- a/src/renderer/App.test.tsx
+++ b/src/renderer/App.test.tsx
@@ -240,6 +240,7 @@ vi.mock('./components/ProjectRail', async () => {
       onRenameProject,
       onSelectProject,
       projects,
+      unreadProjectIds,
       shellSnapshot,
       onShellChange,
       onRefreshShells,
@@ -254,6 +255,7 @@ vi.mock('./components/ProjectRail', async () => {
       onRenameProject: (project: ProjectRecord, name: string) => Promise<void>
       onSelectProject: (project: ProjectRecord) => void
       projects: ProjectRecord[]
+      unreadProjectIds: ReadonlySet<string>
       shellSnapshot: ShellSnapshot
       onShellChange: (shellId: string | 'automatic') => Promise<void>
       onRefreshShells: () => Promise<void>
@@ -264,6 +266,11 @@ vi.mock('./components/ProjectRail', async () => {
     }) => React.createElement(
       'nav',
       null,
+      React.createElement(
+        'output',
+        { 'data-testid': 'unread-projects' },
+        [...unreadProjectIds].sort().join(',')
+      ),
       ...projects.map((item) => React.createElement(
         React.Fragment,
         { key: item.id },
@@ -334,6 +341,7 @@ vi.mock('./components/TaskSidebar', async () => {
       activeProject,
       displayedTasks,
       onLoadTask,
+      onDeleteTask,
       onRenameTask,
       onShowMoreTasks,
       onStartNewTask,
@@ -343,6 +351,7 @@ vi.mock('./components/TaskSidebar', async () => {
       activeProject: ProjectRecord | null
       displayedTasks: TaskRecord[]
       onLoadTask: (task: TaskRecord) => void
+      onDeleteTask: (task: TaskRecord) => Promise<void>
       onRenameTask: (task: TaskRecord, title: string) => Promise<void>
       onShowMoreTasks: () => void
       onStartNewTask: () => void
@@ -359,6 +368,7 @@ vi.mock('./components/TaskSidebar', async () => {
       showDraftTask
         ? React.createElement('div', { 'data-testid': 'draft-task' }, '草稿任务')
         : null,
+      React.createElement('output', { 'data-testid': 'task-count' }, String(totalTaskCount)),
       ...displayedTasks.map((task) => React.createElement(
         React.Fragment,
         { key: task.id },
@@ -370,7 +380,11 @@ vi.mock('./components/TaskSidebar', async () => {
         React.createElement('button', {
           onClick: () => void onRenameTask(task, '手动名称'),
           type: 'button'
-        }, `重命名 ${task.title}`)
+        }, `重命名 ${task.title}`),
+        React.createElement('button', {
+          onClick: () => void onDeleteTask(task),
+          type: 'button'
+        }, `删除任务 ${task.title}`)
       )),
       displayedTasks.length < totalTaskCount
         ? React.createElement('button', {
@@ -652,12 +666,13 @@ function runtimeState(
   definition: WorkflowDefinition,
   task?: TaskRecord
 ): WorkflowRuntimeState {
+  const projectId = task?.project_id ?? project.id
   return {
     taskId,
-    projectId: project.id,
-    projectDir: project.path,
+    projectId,
+    projectDir: projectId === otherProject.id ? otherProject.path : project.path,
     workflowId: definition.id,
-    status: task?.status === 'completed' ? 'completed' : 'running',
+    status: task?.status ?? 'running',
     currentNodeId: definition.nodes[0].id,
     variables: { prompt: 'saved prompt' },
     nodeRuns: {},
@@ -757,6 +772,7 @@ function setupApi(options: {
     setLastOpenedWorkspace: vi.fn().mockResolvedValue(undefined),
     renameProject: vi.fn().mockResolvedValue(undefined),
     updateTaskTitle: vi.fn().mockResolvedValue(undefined),
+    deleteTask: vi.fn().mockResolvedValue(undefined),
     setDesignerState: vi.fn().mockResolvedValue(undefined),
     setProjectDefaultWorkflow: vi.fn().mockResolvedValue(undefined),
     saveWorkflow: vi.fn().mockImplementation((workflow: WorkflowDefinition) => Promise.resolve({
@@ -771,6 +787,7 @@ function setupApi(options: {
     retryProcess: vi.fn().mockResolvedValue({ sessionId: 'session-1' }),
     killProcess: vi.fn().mockResolvedValue(true),
     stopWorkflow: vi.fn().mockResolvedValue(undefined),
+    updateWorkflowVariables: vi.fn().mockResolvedValue(undefined),
     updateShell: vi.fn().mockResolvedValue(data.shell),
     refreshShells: vi.fn().mockResolvedValue(data.shell),
     getUpdateState: vi.fn().mockResolvedValue(initialUpdateState),
@@ -1048,6 +1065,275 @@ describe('App task pagination', () => {
     expect(screen.queryByRole('button', { name: '加载 项目二任务 11' })).toBeNull()
     expect(screen.queryByRole('button', { name: '加载 项目一任务 20' })).toBeNull()
     expect(screen.getByRole('button', { name: '查看更多' })).toBeTruthy()
+  })
+})
+
+describe('App project task isolation and unread state', () => {
+  const thirdProject: ProjectRecord = {
+    ...project,
+    id: 'project-3',
+    name: 'Third Project',
+    path: '/third-repo'
+  }
+
+  it('keeps background updates out of the current rows, count, pagination and workspace', async () => {
+    const projectTasks = taskRecords(project, 12, 'Current')
+    const data = bootstrap(projectTasks)
+    data.projects = [project, otherProject, thirdProject]
+    const { listeners } = setupApi({ data })
+
+    await renderBootstrappedApp()
+    await screen.findByRole('button', { name: '加载 Current 10' })
+    fireEvent.click(screen.getByRole('button', { name: '查看更多' }))
+    expect(screen.getByTestId('task-count').textContent).toBe('12')
+    expect(screen.getByTestId('variables').textContent).toBe('{"prompt":"default a"}')
+
+    const backgroundTask = taskRecords(otherProject, 1, 'Background')[0]
+    backgroundTask.status = 'waiting-input'
+    const thirdTask = taskRecords(thirdProject, 1, 'Third')[0]
+    thirdTask.status = 'failed'
+    act(() => {
+      listeners.workflowState?.(runtimeState(backgroundTask.id, workflowB, backgroundTask))
+      listeners.workflowState?.(runtimeState(thirdTask.id, workflowA, thirdTask))
+    })
+
+    expect(screen.getByTestId('task-count').textContent).toBe('12')
+    expect(screen.getByRole('button', { name: '加载 Current 12' })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: '加载 Background 1' })).toBeNull()
+    expect(screen.queryByRole('button', { name: '加载 Third 1' })).toBeNull()
+    expect(screen.queryByRole('button', { name: '查看更多' })).toBeNull()
+    expect(screen.getByTestId('variables').textContent).toBe('{"prompt":"default a"}')
+    expect(screen.getByTestId('unread-projects').textContent).toBe('project-2,project-3')
+  })
+
+  it('keeps a marker while loading, merges a newer event, and clears only that project on success', async () => {
+    const projectTasks = taskRecords(project, 1, 'Current')
+    const backgroundTask = taskRecords(otherProject, 1, 'Background')[0]
+    backgroundTask.status = 'waiting-input'
+    const thirdTask = taskRecords(thirdProject, 1, 'Third')[0]
+    thirdTask.status = 'running'
+    const pendingBackgroundList = deferred<TaskRecord[]>()
+    const data = bootstrap(projectTasks)
+    data.projects = [project, otherProject, thirdProject]
+    const { api, listeners } = setupApi({ data })
+    api.listTasks.mockImplementation((projectId: string) => {
+      if (projectId === otherProject.id) return pendingBackgroundList.promise
+      return Promise.resolve(projectTasks)
+    })
+
+    await renderBootstrappedApp()
+    await screen.findByRole('button', { name: '加载 Current 1' })
+    act(() => {
+      listeners.workflowState?.(runtimeState(backgroundTask.id, workflowB, backgroundTask))
+      listeners.workflowState?.(runtimeState(thirdTask.id, workflowA, thirdTask))
+    })
+    fireEvent.click(screen.getByRole('button', { name: '切换项目 Other Project' }))
+    await waitFor(() => expect(api.listTasks).toHaveBeenCalledWith(otherProject.id))
+    expect(screen.getByTestId('unread-projects').textContent).toBe('project-2,project-3')
+    expect(screen.getByTestId('task-count').textContent).toBe('0')
+
+    const completedTask = {
+      ...backgroundTask,
+      status: 'completed' as const,
+      updated_at: '2026-08-10T19:31:00.000Z'
+    }
+    act(() => listeners.workflowState?.(runtimeState(completedTask.id, workflowB, completedTask)))
+    await act(async () => {
+      pendingBackgroundList.resolve([backgroundTask, projectTasks[0]])
+      await pendingBackgroundList.promise
+    })
+
+    const row = screen.getByRole('button', { name: '加载 Background 1' })
+    expect(row.getAttribute('data-task-status')).toBe('completed')
+    expect(screen.queryByRole('button', { name: '加载 Current 1' })).toBeNull()
+    expect(screen.getByTestId('task-count').textContent).toBe('1')
+    expect(screen.getByTestId('unread-projects').textContent).toBe('project-3')
+  })
+
+  it('does not clear unread on a failed list and clears it after a later successful visit', async () => {
+    const projectTasks = taskRecords(project, 1, 'Current')
+    const backgroundTasks = taskRecords(otherProject, 1, 'Background')
+    const data = bootstrap(projectTasks)
+    data.projects = [project, otherProject]
+    const { api, listeners } = setupApi({ data })
+    let backgroundLoads = 0
+    api.listTasks.mockImplementation((projectId: string) => {
+      if (projectId !== otherProject.id) return Promise.resolve(projectTasks)
+      backgroundLoads += 1
+      return backgroundLoads === 1
+        ? Promise.reject(new Error('list failed'))
+        : Promise.resolve(backgroundTasks)
+    })
+
+    await renderBootstrappedApp()
+    act(() => listeners.workflowState?.(runtimeState(
+      backgroundTasks[0].id,
+      workflowB,
+      backgroundTasks[0]
+    )))
+    fireEvent.click(screen.getByRole('button', { name: '切换项目 Other Project' }))
+    await waitFor(() => expect(backgroundLoads).toBe(1))
+    expect(screen.getByTestId('unread-projects').textContent).toBe('project-2')
+
+    fireEvent.click(screen.getByRole('button', { name: '切换项目 Project' }))
+    await screen.findByRole('button', { name: '加载 Current 1' })
+    fireEvent.click(screen.getByRole('button', { name: '切换项目 Other Project' }))
+    await screen.findByRole('button', { name: '加载 Background 1' })
+    expect(screen.getByTestId('unread-projects').textContent).toBe('')
+  })
+
+  it('rejects an old A list after navigating A to B to A', async () => {
+    const oldA = deferred<TaskRecord[]>()
+    const currentA = deferred<TaskRecord[]>()
+    const data = bootstrap([])
+    data.projects = [project, otherProject]
+    const { api } = setupApi({ data })
+    let aLoads = 0
+    api.listTasks.mockImplementation((projectId: string) => {
+      if (projectId === otherProject.id) return Promise.resolve([])
+      aLoads += 1
+      return aLoads === 1 ? oldA.promise : currentA.promise
+    })
+
+    await renderBootstrappedApp()
+    await waitFor(() => expect(aLoads).toBe(1))
+    fireEvent.click(screen.getByRole('button', { name: '切换项目 Other Project' }))
+    await waitFor(() => expect(api.listTasks).toHaveBeenCalledWith(otherProject.id))
+    fireEvent.click(screen.getByRole('button', { name: '切换项目 Project' }))
+    await waitFor(() => expect(aLoads).toBe(2))
+
+    await act(async () => {
+      oldA.resolve([{
+        ...taskRecords(project, 1)[0],
+        id: 'old',
+        title: 'Task old'
+      }])
+      await oldA.promise
+    })
+    expect(screen.queryByRole('button', { name: '加载 Task old' })).toBeNull()
+    await act(async () => {
+      currentA.resolve([{
+        ...taskRecords(project, 1)[0],
+        id: 'current',
+        title: 'Task current'
+      }])
+      await currentA.promise
+    })
+    expect(screen.getByRole('button', { name: '加载 Task current' })).toBeTruthy()
+  })
+
+  it('keeps a delayed launch result in its owning project and still cleans that draft', async () => {
+    const data = bootstrap([])
+    data.projects = [project, otherProject]
+    const pendingStart = deferred<WorkflowRuntimeState>()
+    const { api, listeners } = setupApi({ data, drafts: {} })
+    api.listTasks.mockResolvedValue([])
+    api.startWorkflow.mockReturnValueOnce(pendingStart.promise)
+
+    const newTaskButton = await renderBootstrappedApp()
+    fireEvent.click(newTaskButton)
+    await waitFor(() => expect(api.saveTaskDraft).toHaveBeenCalledWith(
+      project.id,
+      expect.anything(),
+      true
+    ))
+    fireEvent.click(screen.getByRole('button', { name: '运行' }))
+    await waitFor(() => expect(api.startWorkflow).toHaveBeenCalledOnce())
+    const request = api.startWorkflow.mock.calls[0][0] as WorkflowRuntimeStartOptions
+
+    fireEvent.click(screen.getByRole('button', { name: '切换项目 Other Project' }))
+    await waitFor(() => expect(api.listTasks).toHaveBeenCalledWith(otherProject.id))
+    const launchedTask: TaskRecord = {
+      id: request.taskId,
+      project_id: project.id,
+      title: 'Delayed A task',
+      status: 'running',
+      created_at: '2026-08-10T19:30:00.000Z',
+      updated_at: '2026-08-10T19:30:00.000Z'
+    }
+    await act(async () => {
+      pendingStart.resolve(runtimeState(request.taskId, request.workflow, launchedTask))
+      await pendingStart.promise
+    })
+    act(() => listeners.workflowState?.(runtimeState(
+      request.taskId,
+      request.workflow,
+      launchedTask
+    )))
+
+    expect(screen.getByTestId('task-count').textContent).toBe('0')
+    expect(screen.queryByRole('button', { name: '加载 Delayed A task' })).toBeNull()
+    expect(screen.getByTestId('unread-projects').textContent).toBe(project.id)
+    await waitFor(() => expect(api.deleteTaskDraft).toHaveBeenCalledWith(project.id))
+  })
+
+  it('ignores late restore, rename and delete results after switching projects', async () => {
+    const selectedTask = taskRecords(project, 1, 'Selected A')[0]
+    const renamedTask = {
+      ...taskRecords(project, 1, 'Rename A')[0],
+      id: 'project-1-task-to-rename'
+    }
+    const backgroundTask = taskRecords(otherProject, 1, 'Stable B')[0]
+    const data = bootstrap([selectedTask, renamedTask])
+    data.projects = [project, otherProject]
+    const restoreA = deferred<{
+      state: WorkflowRuntimeState
+      workflow: WorkflowDefinition
+      terminalSessions: TerminalSession[]
+    }>()
+    const renameA = deferred<void>()
+    const deleteA = deferred<void>()
+    const { api } = setupApi({ data })
+    api.listTasks.mockImplementation((projectId: string) => Promise.resolve(
+      projectId === otherProject.id ? [backgroundTask] : [selectedTask, renamedTask]
+    ))
+    api.restoreWorkflowState.mockImplementation((taskId: string) => {
+      if (taskId === selectedTask.id) return restoreA.promise
+      if (taskId === backgroundTask.id) {
+        return Promise.resolve({
+          state: runtimeState(backgroundTask.id, workflowB, backgroundTask),
+          workflow: workflowB,
+          terminalSessions: []
+        })
+      }
+      return Promise.resolve(null)
+    })
+    api.updateTaskTitle.mockReturnValueOnce(renameA.promise)
+    api.deleteTask.mockReturnValueOnce(deleteA.promise)
+    await renderBootstrappedApp()
+
+    fireEvent.click(await screen.findByRole('button', { name: '加载 Selected A 1' }))
+    fireEvent.click(screen.getByRole('button', { name: '重命名 Rename A 1' }))
+    fireEvent.click(screen.getByRole('button', { name: '删除任务 Selected A 1' }))
+    await waitFor(() => {
+      expect(api.restoreWorkflowState).toHaveBeenCalledWith(selectedTask.id)
+      expect(api.updateTaskTitle).toHaveBeenCalledWith(renamedTask.id, '手动名称')
+      expect(api.deleteTask).toHaveBeenCalledWith(selectedTask.id)
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: '切换项目 Other Project' }))
+    fireEvent.click(await screen.findByRole('button', { name: '加载 Stable B 1' }))
+    await waitFor(() => expect(screen.getByTitle('流程 B')).toBeTruthy())
+    expect(screen.getByTestId('variables').textContent).toBe('{"prompt":"saved prompt"}')
+
+    await act(async () => {
+      renameA.resolve(undefined)
+      deleteA.resolve(undefined)
+      restoreA.resolve({
+        state: runtimeState(selectedTask.id, workflowA, selectedTask),
+        workflow: { ...workflowA, name: 'Late A snapshot' },
+        terminalSessions: []
+      })
+      await Promise.all([renameA.promise, deleteA.promise, restoreA.promise])
+    })
+
+    expect(screen.getByTestId('task-count').textContent).toBe('1')
+    expect(screen.getByRole('button', { name: '加载 Stable B 1' })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: '加载 Selected A 1' })).toBeNull()
+    expect(screen.queryByRole('button', { name: '加载 手动名称' })).toBeNull()
+    expect(screen.getByTitle('Stable B 1')).toBeTruthy()
+    expect(screen.getByTitle('流程 B')).toBeTruthy()
+    expect(screen.getByTestId('variables').textContent).toBe('{"prompt":"saved prompt"}')
   })
 })
 
@@ -2469,6 +2755,94 @@ describe('App restored workflow snapshots', () => {
       await Promise.resolve()
     })
     expect(screen.getByTitle('流程 A 快照')).toBeTruthy()
+  })
+
+  it('loads the workflow and sessions without letting a pending restore overwrite a newer event', async () => {
+    await i18n.changeLanguage('en')
+    const task: TaskRecord = {
+      id: 'task-racing-restore',
+      project_id: project.id,
+      title: 'Racing restore task',
+      status: 'running',
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-02T00:00:00.000Z'
+    }
+    const restoredWorkflow: WorkflowDefinition = {
+      id: 'restored-terminal-workflow',
+      name: 'Restored terminal snapshot',
+      nodes: [
+        { id: 'start', type: 'start', name: 'Start', config: { variables: [] } },
+        {
+          id: 'terminal',
+          type: 'non-interactive-terminal',
+          name: 'Restored terminal',
+          config: { command: 'echo restored', cwd: '/repo', successExitCodes: [0] }
+        },
+        { id: 'end', type: 'end', name: 'End', config: {} }
+      ],
+      edges: [
+        { id: 'start-terminal', from: 'start', to: 'terminal' },
+        { id: 'terminal-end', from: 'terminal', to: 'end' }
+      ]
+    }
+    const restoreDeferred = deferred<{
+      state: WorkflowRuntimeState
+      workflow: WorkflowDefinition
+      terminalSessions: TerminalSession[]
+    }>()
+    const { api, listeners } = setupApi({ data: bootstrap([task]) })
+    api.restoreWorkflowState.mockReturnValueOnce(restoreDeferred.promise)
+    await renderBootstrappedApp()
+
+    fireEvent.click(await screen.findByRole('button', { name: '加载 Racing restore task' }))
+    await waitFor(() => expect(api.restoreWorkflowState).toHaveBeenCalledWith(task.id))
+    const liveTask: TaskRecord = {
+      ...task,
+      status: 'completed',
+      updated_at: '2026-01-04T00:00:00.000Z'
+    }
+    act(() => listeners.workflowState?.({
+      ...runtimeState(task.id, restoredWorkflow, liveTask),
+      currentNodeId: 'terminal',
+      variables: { prompt: 'live value' },
+      nodeRuns: { terminal: { nodeId: 'terminal', status: 'completed' } },
+      executionOrder: ['start', 'terminal'],
+      workflowCompleted: true
+    }))
+
+    const staleTask: TaskRecord = {
+      ...task,
+      updated_at: '2026-01-01T00:00:00.000Z'
+    }
+    await act(async () => {
+      restoreDeferred.resolve({
+        state: {
+          ...runtimeState(task.id, restoredWorkflow, staleTask),
+          currentNodeId: 'terminal',
+          variables: { prompt: 'stale value' },
+          nodeRuns: { terminal: { nodeId: 'terminal', status: 'running' } },
+          executionOrder: ['start', 'terminal']
+        },
+        workflow: restoredWorkflow,
+        terminalSessions: [{
+          id: 'restored-session',
+          task_id: task.id,
+          node_id: 'terminal',
+          kind: 'non-interactive',
+          command: 'echo restored',
+          cwd: '/repo',
+          status: 'closed',
+          transcript: 'restored transcript'
+        }]
+      })
+      await restoreDeferred.promise
+    })
+
+    expect(screen.getByTitle('Restored terminal snapshot')).toBeTruthy()
+    expect(screen.getByTestId('variables').textContent).toBe('{"prompt":"live value"}')
+    expect(screen.getByTestId('terminal-transcript').textContent).toBe('restored transcript')
+    expect(screen.getByRole('button', { name: '加载 Racing restore task' })
+      .getAttribute('data-task-status')).toBe('completed')
   })
 })
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -2,6 +2,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useReducer,
   useRef,
   useState,
   type CSSProperties,
@@ -92,8 +93,7 @@ import {
   getNodeDetailZoomTarget,
   getNodeDetailZoomTitle,
   getNextActiveProjectIdAfterDelete,
-  shouldResetActiveTaskAfterDelete,
-  mergeTaskRecord
+  shouldResetActiveTaskAfterDelete
 } from './utils'
 import { getWorkflowAction } from './executionActions'
 import type { NodeDetailZoomTarget, TerminalSession } from './utils'
@@ -126,6 +126,16 @@ import type {
 } from './appTypes'
 import { applySkin, DEFAULT_SKIN, type Skin } from './theme'
 import { i18n, syncI18nLanguage } from './i18n'
+import {
+  canApplyRuntimeState,
+  createProjectTaskState,
+  getTaskObservationVersion,
+  isRuntimeStateIdentityValid,
+  projectTaskReducer,
+  selectCurrentProjectTasks,
+  type ProjectTaskAction,
+  type RuntimeStateSource
+} from './projectTaskState'
 import { useTranslation } from 'react-i18next'
 import type { TranslationKey } from '../shared/i18n/types'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
@@ -298,7 +308,11 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
   const { t } = useTranslation()
   const [bootstrap, setBootstrap] = useState<Bootstrap>(fallbackBootstrap)
   const [projects, setProjects] = useState<ProjectRecord[]>([])
-  const [tasks, setTasks] = useState<TaskRecord[]>([])
+  const [projectTaskState, projectTaskDispatch] = useReducer(
+    projectTaskReducer,
+    undefined,
+    createProjectTaskState
+  )
   const [visibleTaskCount, setVisibleTaskCount] = useState(TASK_BATCH_SIZE)
   const [activeProjectId, setActiveProjectId] = useState<string | null>(null)
   const [workflow, setWorkflow] = useState<WorkflowDefinition>(emptyWorkflow)
@@ -359,6 +373,9 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
   const [executionOrder, setExecutionOrder] = useState<string[]>([])
   const activeTaskIdRef = useRef(activeTaskId)
   const activeProjectIdRef = useRef(activeProjectId)
+  const projectTaskStateRef = useRef(projectTaskState)
+  const projectActivationIdRef = useRef(0)
+  const taskListRequestIdRef = useRef(0)
   const workflowRef = useRef(workflow)
   const variablesRef = useRef(variables)
   const draftStartedRef = useRef(draftStarted)
@@ -394,6 +411,7 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
   editingWorkflowIdRef.current = editingWorkflow?.id ?? null
   workflowIdRef.current = workflow.id
   activeProjectIdRef.current = activeProjectId
+  projectTaskStateRef.current = projectTaskState
   workflowRef.current = workflow
   variablesRef.current = variables
   draftStartedRef.current = draftStarted
@@ -402,6 +420,27 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
   startingWorkflowTaskIdRef.current = startingWorkflowTaskId
   pendingWorkflowIdRef.current = pendingWorkflowId
   availableWorkflowsRef.current = bootstrap.workflows
+
+  function dispatchProjectTaskState(action: ProjectTaskAction) {
+    const nextState = projectTaskReducer(projectTaskStateRef.current, action)
+    projectTaskStateRef.current = nextState
+    projectTaskDispatch(action)
+    return nextState
+  }
+
+  function syncProjectRecords(nextProjects: ProjectRecord[]) {
+    setProjects(nextProjects)
+    dispatchProjectTaskState({ type: 'syncProjects', projects: nextProjects })
+  }
+
+  function commitActiveProject(projectId: string | null) {
+    const activationId = projectActivationIdRef.current + 1
+    projectActivationIdRef.current = activationId
+    activeProjectIdRef.current = projectId
+    setActiveProjectId(projectId)
+    dispatchProjectTaskState({ type: 'activateProject', projectId, activationId })
+  }
+
   const activeRuntimeStatus = runtimeState?.taskId === activeTaskId ? runtimeState.status : null
   const isRunning = activeRuntimeStatus === 'running'
   const isWaitingForInput = activeRuntimeStatus === 'waiting-input'
@@ -477,9 +516,10 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
   const taskGraphFitViewOptions = taskGraphFocusNodeId && taskFlowNodes.some((node) => node.id === taskGraphFocusNodeId)
     ? { nodes: [{ id: taskGraphFocusNodeId }], padding: 0.2, maxZoom: 1 }
     : { padding: 0.2, maxZoom: 1 }
-  const displayedTasks = tasks.slice(0, visibleTaskCount)
-  const persistedActiveTask = tasks.find((task) => task.id === activeTaskId)
-  const persistedTaskIds = tasks.map((task) => task.id)
+  const currentProjectTasks = selectCurrentProjectTasks(projectTaskState, activeProjectId)
+  const displayedTasks = currentProjectTasks.slice(0, visibleTaskCount)
+  const persistedActiveTask = currentProjectTasks.find((task) => task.id === activeTaskId)
+  const persistedTaskIds = currentProjectTasks.map((task) => task.id)
   const canSwitchWorkflow = Boolean(
     activeProject &&
     availableWorkflows.length > 0 &&
@@ -765,15 +805,27 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
 
   function applyRuntimeState(
     state: WorkflowRuntimeState,
-    options: { moveTaskToFront?: boolean } = {}
-  ) {
-    if (state.task) {
-      setTasks((current) => mergeTaskRecord(
-        current,
-        state.task as TaskRecord,
-        options.moveTaskToFront ?? true
-      ))
+    options: {
+      moveTaskToFront?: boolean
+      source: RuntimeStateSource
+      observationVersion?: number
     }
+  ) {
+    const currentProjectTaskState = projectTaskStateRef.current
+    if (!isRuntimeStateIdentityValid(currentProjectTaskState, state)) return
+    const shouldApply = canApplyRuntimeState(
+      currentProjectTaskState,
+      state,
+      options.source,
+      options.observationVersion
+    )
+    dispatchProjectTaskState({
+      type: 'runtimeReceived',
+      state,
+      source: options.source,
+      moveTaskToFront: options.moveTaskToFront ?? true,
+      observationVersion: options.observationVersion
+    })
     const pendingDraftLaunch = pendingDraftLaunchesRef.current.get(state.taskId)
     if (
       state.task &&
@@ -785,7 +837,11 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
         void deletePersistedDraft(state.projectId)
       }
     }
-    if (state.taskId !== activeTaskIdRef.current) return
+    if (
+      !shouldApply ||
+      state.projectId !== activeProjectIdRef.current ||
+      state.taskId !== activeTaskIdRef.current
+    ) return
     activeTaskPersistedRef.current = true
     updateRuntimeState(state)
     updateNewTaskDraft(false)
@@ -896,7 +952,7 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
         startNodeId
       })) as WorkflowRuntimeState | undefined
       if (state) {
-        applyRuntimeState(state)
+        applyRuntimeState(state, { source: 'command' })
       }
     } catch (error) {
       if (pendingDraftLaunchRegistered) pendingDraftLaunchesRef.current.delete(taskId)
@@ -922,7 +978,7 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
   async function continueWorkflowWithVariables() {
     try {
       const state = (await window.cliLoom?.updateWorkflowVariables(activeTaskId, variables)) as WorkflowRuntimeState | null | undefined
-      if (state) applyRuntimeState(state)
+      if (state) applyRuntimeState(state, { source: 'command' })
     } catch (error) {
       handleError(error, 'updateWorkflowVariables')
     }
@@ -931,7 +987,7 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
   async function continueBranchWithVariables(branchId: string) {
     try {
       const state = (await window.cliLoom?.updateWorkflowVariables(activeTaskId, branchRuns[branchId]?.variables ?? {}, branchId)) as WorkflowRuntimeState | null | undefined
-      if (state) applyRuntimeState(state)
+      if (state) applyRuntimeState(state, { source: 'command' })
     } catch (error) {
       handleError(error, 'updateWorkflowBranchVariables')
     }
@@ -940,7 +996,7 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
   async function stopWorkflow() {
     try {
       const state = (await window.cliLoom?.stopWorkflow(activeTaskId)) as WorkflowRuntimeState | null | undefined
-      if (state) applyRuntimeState(state)
+      if (state) applyRuntimeState(state, { source: 'command' })
       else {
         const currentState = runtimeStateRef.current
         if (currentState?.taskId === activeTaskId) {
@@ -975,7 +1031,7 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
         nodeId,
         branchId
       )) as WorkflowRuntimeState | undefined
-      if (state) applyRuntimeState(state)
+      if (state) applyRuntimeState(state, { source: 'command' })
     } catch (error) {
       handleError(error, 'retryWorkflowNode')
     }
@@ -1059,7 +1115,7 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
       availableWorkflowsRef.current = data.workflows
       setBootstrap(data)
       setWorkflowRevisions(toWorkflowRevisionMap(data.workflowRecords))
-      setProjects(data.projects)
+      syncProjectRecords(data.projects)
       setSessions(data.terminalSessions)
       setProjectRailWidth(data.settings.layout.projectRailWidth)
       setTaskSidebarWidth(data.settings.layout.taskSidebarWidth)
@@ -1084,8 +1140,7 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
       updateNewTaskDraft(false)
       updatePendingWorkflowId(null)
       updateRuntimeState(null)
-      activeProjectIdRef.current = initialProject?.id ?? null
-      setActiveProjectId(initialProject?.id ?? null)
+      commitActiveProject(initialProject?.id ?? null)
       const initialWorkflow = data.workflows.find((item) => item.id === initialProject?.default_workflow_id)
         ?? data.workflows[0]
         ?? emptyWorkflow
@@ -1205,7 +1260,7 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
     })
     const removeProject = window.cliLoom?.onProjectChanged(() => {
       window.cliLoom?.listProjects().then((records: ProjectRecord[]) => {
-        setProjects(records)
+        syncProjectRecords(records)
       }).catch((error: unknown) => handleError(error, 'refreshProjects'))
     })
     return () => {
@@ -1226,19 +1281,37 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
 
   useEffect(() => {
     setVisibleTaskCount(TASK_BATCH_SIZE)
-    if (!activeProjectId) {
-      setTasks([])
-      return
-    }
+    if (!activeProjectId) return
     let cancelled = false
+    const activationId = projectActivationIdRef.current
+    const requestId = taskListRequestIdRef.current + 1
+    taskListRequestIdRef.current = requestId
+    dispatchProjectTaskState({
+      type: 'listStarted',
+      projectId: activeProjectId,
+      activationId,
+      requestId
+    })
     window.cliLoom?.listTasks(activeProjectId).then((records: TaskRecord[]) => {
-      if (cancelled) return
-      setTasks(records)
+      if (
+        cancelled ||
+        activeProjectIdRef.current !== activeProjectId ||
+        projectActivationIdRef.current !== activationId ||
+        taskListRequestIdRef.current !== requestId
+      ) return
+      const nextProjectTaskState = dispatchProjectTaskState({
+        type: 'listSucceeded',
+        projectId: activeProjectId,
+        activationId,
+        requestId,
+        tasks: records
+      })
+      const mergedTasks = selectCurrentProjectTasks(nextProjectTaskState, activeProjectId)
 
       const pendingTask = pendingStartupTaskRef.current
       if (!pendingTask || pendingTask.projectId !== activeProjectId) return
       pendingStartupTaskRef.current = null
-      const task = records.find((record) => record.id === pendingTask.taskId)
+      const task = mergedTasks.find((record) => record.id === pendingTask.taskId)
       if (!task) {
         rememberWorkspace(activeProjectId, null)
         // The remembered task is gone, so fall back to the project's draft
@@ -1247,17 +1320,28 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
         if (fallbackProject) restoreStartupDraft(fallbackProject)
         return
       }
-      const taskIndex = records.indexOf(task)
+      const taskIndex = mergedTasks.indexOf(task)
       if (taskIndex >= TASK_BATCH_SIZE) {
         setVisibleTaskCount(Math.ceil((taskIndex + 1) / TASK_BATCH_SIZE) * TASK_BATCH_SIZE)
       }
       loadTask(task)
     }).catch((error: unknown) => {
+      if (
+        cancelled ||
+        activeProjectIdRef.current !== activeProjectId ||
+        projectActivationIdRef.current !== activationId ||
+        taskListRequestIdRef.current !== requestId
+      ) return
+      dispatchProjectTaskState({
+        type: 'listFailed',
+        projectId: activeProjectId,
+        activationId,
+        requestId
+      })
       handleError(error, 'listTasks')
       // A failed startup task lookup must not strand the workspace without
       // the draft fallback, and the stale marker must not survive to a
       // later navigation of the same project.
-      if (cancelled) return
       const pendingTask = pendingStartupTaskRef.current
       if (!pendingTask || pendingTask.projectId !== activeProjectId) return
       pendingStartupTaskRef.current = null
@@ -1393,7 +1477,7 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
 
   useEffect(() => {
     const removeState = window.cliLoom?.onWorkflowState((event) => {
-      applyRuntimeState(event as WorkflowRuntimeState)
+      applyRuntimeState(event as WorkflowRuntimeState, { source: 'event' })
     })
     return () => removeState?.()
   }, [])
@@ -1445,15 +1529,13 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
       if (draftLoadRequestRef.current !== requestId) return
       const nextProjects = (await window.cliLoom?.listProjects()) as ProjectRecord[]
       if (draftLoadRequestRef.current !== requestId) return
-      setProjects(nextProjects)
+      syncProjectRecords(nextProjects)
       // The folder picker also returns an existing project when the selected
       // path is already registered. Keep the current editor in place in that
       // case; switching away and back is the explicit navigation action that
       // should reset the transient workspace.
       if (project.id === activeProjectIdRef.current) return
-      activeProjectIdRef.current = project.id
-      setActiveProjectId(project.id)
-      setTasks([])
+      commitActiveProject(project.id)
       resetTaskWorkspaceForProject(project, { draftStarted: false })
       rememberWorkspace(project.id, null)
       // Landing on the project through the folder picker is a project switch
@@ -1477,10 +1559,8 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
       const nextProjects = (await window.cliLoom?.listProjects()) as ProjectRecord[]
       const nextActiveProjectId = getNextActiveProjectIdAfterDelete({ projects: nextProjects, deletedProjectId: project.id })
       const nextProject = nextProjects.find((item) => item.id === nextActiveProjectId) ?? null
-      setProjects(nextProjects)
-      activeProjectIdRef.current = nextActiveProjectId
-      setActiveProjectId(nextActiveProjectId)
-      setTasks([])
+      syncProjectRecords(nextProjects)
+      commitActiveProject(nextActiveProjectId)
       resetTaskWorkspaceForProject(nextProject, { draftStarted: false })
       rememberWorkspace(nextProject?.id ?? null, null)
       // Falling back to a neighboring project is a project switch too, so
@@ -1512,9 +1592,12 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
     if (!normalizedTitle) return
     try {
       await window.cliLoom?.updateTaskTitle(task.id, normalizedTitle)
-      setTasks((current) => current.map((item) => (
-        item.id === task.id ? { ...item, title: normalizedTitle } : item
-      )))
+      dispatchProjectTaskState({
+        type: 'taskRenamed',
+        projectId: task.project_id,
+        taskId: task.id,
+        title: normalizedTitle
+      })
     } catch (error) {
       handleError(error, 'renameTask')
       throw error
@@ -1524,10 +1607,21 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
   async function deleteTaskRecord(task: TaskRecord) {
     try {
       await window.cliLoom?.deleteTask(task.id)
-      setTasks((current) => current.filter((item) => item.id !== task.id))
-      if (shouldResetActiveTaskAfterDelete({ activeTaskId, deletedTaskId: task.id })) {
-        resetTaskWorkspaceForProject(activeProject, { draftStarted: false })
-        rememberWorkspace(activeProject?.id ?? null, null)
+      dispatchProjectTaskState({
+        type: 'taskDeleted',
+        projectId: task.project_id,
+        taskId: task.id
+      })
+      if (
+        activeProjectIdRef.current === task.project_id &&
+        shouldResetActiveTaskAfterDelete({
+          activeTaskId: activeTaskIdRef.current,
+          deletedTaskId: task.id
+        })
+      ) {
+        const currentProject = projects.find((item) => item.id === task.project_id) ?? null
+        resetTaskWorkspaceForProject(currentProject, { draftStarted: false })
+        rememberWorkspace(task.project_id, null)
       }
     } catch (error) {
       handleError(error, 'deleteTask')
@@ -1857,9 +1951,7 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
     pendingDraftLoadRef.current = null
     await flushActiveDraft()
     if (draftLoadRequestRef.current !== requestId) return
-    activeProjectIdRef.current = project.id
-    setActiveProjectId(project.id)
-    setTasks([])
+    commitActiveProject(project.id)
     resetTaskWorkspaceForProject(project, { draftStarted: false })
     rememberWorkspace(project.id, null)
     // Switching to a project that has a persisted draft restores it directly
@@ -2157,6 +2249,7 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
       <ProjectRail
         projects={projects}
         activeProjectId={activeProjectId}
+        unreadProjectIds={projectTaskState.unreadProjectIds}
         onSelectProject={selectProject}
         onReorderProject={reorderProject}
         onAddProject={chooseFolder}
@@ -2342,7 +2435,7 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
         activeProject={activeProject}
         availableWorkflows={availableWorkflows}
         displayedTasks={displayedTasks}
-        totalTaskCount={tasks.length}
+        totalTaskCount={currentProjectTasks.length}
         activeTaskId={activeTaskId}
         onSetDefaultWorkflow={setDefaultWorkflow}
         onStartNewTask={startNewTask}
@@ -2350,7 +2443,7 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
         onRenameTask={renameTask}
         onDeleteTask={deleteTaskRecord}
         onShowMoreTasks={() => setVisibleTaskCount((current) => (
-          Math.min(current + TASK_BATCH_SIZE, tasks.length)
+          Math.min(current + TASK_BATCH_SIZE, currentProjectTasks.length)
         ))}
       />
 
@@ -2886,6 +2979,11 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
 
     const requestId = taskLoadRequestRef.current + 1
     taskLoadRequestRef.current = requestId
+    const restoreObservationVersion = getTaskObservationVersion(
+      projectTaskStateRef.current,
+      task.project_id,
+      task.id
+    )
     setActiveTaskId(task.id)
     activeTaskIdRef.current = task.id
     activeTaskPersistedRef.current = true
@@ -2901,7 +2999,9 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
     setParallelZoomNodeId(null)
 
     const isCurrentTaskLoad = () => (
-      taskLoadRequestRef.current === requestId && activeTaskIdRef.current === task.id
+      taskLoadRequestRef.current === requestId &&
+      activeProjectIdRef.current === task.project_id &&
+      activeTaskIdRef.current === task.id
     )
 
     const applyTaskContextFallback = async () => {
@@ -2947,11 +3047,28 @@ export function App({ initialSkin = DEFAULT_SKIN }: { initialSkin?: Skin }) {
         terminalSessions?: TerminalSession[]
       } | null | undefined
       if (payload?.state) {
+        const restoredStateIdentityIsValid =
+          payload.state.projectId === task.project_id &&
+          payload.state.taskId === task.id &&
+          isRuntimeStateIdentityValid(projectTaskStateRef.current, payload.state)
+        if (!restoredStateIdentityIsValid) return
+        const shouldApplyRestoredRuntimeState = canApplyRuntimeState(
+          projectTaskStateRef.current,
+          payload.state,
+          'restore',
+          restoreObservationVersion
+        )
         const nextWorkflow = payload.workflow
           ?? availableWorkflows.find((item) => item.id === payload.state?.workflowId)
           ?? workflow
         updateWorkspaceWorkflow(nextWorkflow)
-        applyRuntimeState(payload.state, { moveTaskToFront: false })
+        if (shouldApplyRestoredRuntimeState) {
+          applyRuntimeState(payload.state, {
+            source: 'restore',
+            moveTaskToFront: false,
+            observationVersion: restoreObservationVersion
+          })
+        }
         setViewMode('focus')
       } else {
         await applyTaskContextFallback()

--- a/src/renderer/components/ProjectRail.test.tsx
+++ b/src/renderer/components/ProjectRail.test.tsx
@@ -99,6 +99,7 @@ vi.mock('@/components/ui/alert-dialog', async () => {
 import { ProjectRail } from './ProjectRail'
 
 const defaultUpdateProps = {
+  unreadProjectIds: new Set<string>(),
   updateState: {
     status: 'idle' as const,
     capability: 'installable' as const,
@@ -115,6 +116,77 @@ afterEach(() => {
 })
 
 describe('ProjectRail project actions', () => {
+  it('renders and removes the unread marker with localized accessible text', async () => {
+    await i18n.changeLanguage('en')
+    const projects = [
+      {
+        id: 'project-1',
+        name: 'Current',
+        path: '/repo/current',
+        sort_order: 0,
+        created_at: '2026-08-11T00:00:00.000Z'
+      },
+      {
+        id: 'project-2',
+        name: 'Background',
+        path: '/repo/background',
+        sort_order: 1,
+        created_at: '2026-08-11T00:00:00.000Z'
+      }
+    ]
+    const onSelectProject = vi.fn()
+    const renderRail = (unreadProjectIds: ReadonlySet<string>) => (
+      <I18nextProvider i18n={i18n}>
+        <ProjectRail
+          {...defaultUpdateProps}
+          activeProjectId="project-2"
+          activeSkinId="builtin.light.neutral"
+          language="en"
+          projects={projects}
+          shellSnapshot={{
+            platform: 'linux',
+            preferences: { version: 3, selection: { mode: 'automatic' } },
+            candidates: [],
+            effectiveShell: null,
+            error: undefined
+          }}
+          unreadProjectIds={unreadProjectIds}
+          onAddProject={() => undefined}
+          onLanguageChange={() => undefined}
+          onOpenAppearance={() => undefined}
+          onDeleteProject={async () => undefined}
+          onOpenAssistant={() => undefined}
+          onOpenDesigner={() => undefined}
+          onRefreshShells={async () => undefined}
+          onRenameProject={async () => undefined}
+          onReorderProject={() => undefined}
+          onSelectProject={onSelectProject}
+          onShellChange={async () => undefined}
+          onSkinChange={() => undefined}
+          userSkins={[]}
+        />
+      </I18nextProvider>
+    )
+    const view = render(renderRail(new Set(['project-2'])))
+
+    const unreadButton = screen.getByRole('button', {
+      name: 'Open project Background, unread task status updates'
+    })
+    const marker = view.container.querySelector('[data-project-unread-indicator="true"]')
+    expect(marker?.getAttribute('data-project-id')).toBe('project-2')
+    expect(marker?.className).toContain('size-2')
+    expect(marker?.className).toContain('bg-red-500')
+    expect(marker?.className).toContain('pointer-events-none')
+    expect(screen.getByText('Unread task status updates')).toBeTruthy()
+    fireEvent.click(unreadButton)
+    expect(onSelectProject).toHaveBeenCalledWith(projects[1])
+
+    view.rerender(renderRail(new Set()))
+    expect(view.container.querySelector('[data-project-unread-indicator="true"]')).toBeNull()
+    expect(screen.getByRole('button', { name: 'Open project Background' })).toBeTruthy()
+    expect(screen.queryByText('Unread task status updates')).toBeNull()
+  })
+
   it('moves rename and delete into an ordered project context menu', async () => {
     i18n.changeLanguage('zh')
     const project = {

--- a/src/renderer/components/ProjectRail.tsx
+++ b/src/renderer/components/ProjectRail.tsx
@@ -70,6 +70,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 type ProjectRailProps = {
   projects: ProjectRecord[]
   activeProjectId: string | null
+  unreadProjectIds: ReadonlySet<string>
   onSelectProject: (project: ProjectRecord) => void
   onReorderProject: (dragId: string, dropId: string) => void
   onAddProject: () => void
@@ -95,6 +96,7 @@ type ProjectRailProps = {
 export function ProjectRail({
   projects,
   activeProjectId,
+  unreadProjectIds,
   onSelectProject,
   onReorderProject,
   onAddProject,
@@ -211,6 +213,7 @@ export function ProjectRail({
         <div className="flex min-h-0 w-full min-w-0 flex-1 flex-col items-center gap-2 overflow-x-hidden overflow-y-auto">
           {projects.map((project) => {
             const isActive = project.id === activeProjectId
+            const isUnread = unreadProjectIds.has(project.id)
             return (
               <div className="flex w-full justify-center" key={project.id}>
                 <ContextMenu>
@@ -218,8 +221,13 @@ export function ProjectRail({
                     <TooltipTrigger asChild>
                       <ContextMenuTrigger asChild>
                         <Button
-                          aria-label={t('project:action.openProject', { name: project.name })}
-                          className="size-10 shrink-0 rounded-xl font-heading text-sm"
+                          aria-label={t(
+                            isUnread
+                              ? 'project:action.openProjectWithUnread'
+                              : 'project:action.openProject',
+                            { name: project.name }
+                          )}
+                          className="relative size-10 shrink-0 rounded-xl font-heading text-sm"
                           draggable
                           variant={isActive ? 'default' : 'ghost'}
                           onClick={() => onSelectProject(project)}
@@ -228,6 +236,14 @@ export function ProjectRail({
                           onDrop={(event) => onReorderProject(event.dataTransfer.getData('text/project-id'), project.id)}
                         >
                           {project.name.slice(0, 1).toUpperCase()}
+                          {isUnread && (
+                            <span
+                              aria-hidden="true"
+                              className="pointer-events-none absolute right-1 top-1 size-2 rounded-full bg-red-500 ring-2 ring-sidebar"
+                              data-project-id={project.id}
+                              data-project-unread-indicator="true"
+                            />
+                          )}
                         </Button>
                       </ContextMenuTrigger>
                     </TooltipTrigger>
@@ -235,6 +251,11 @@ export function ProjectRail({
                       <div className="flex max-w-64 flex-col gap-0.5">
                         <strong>{project.name}</strong>
                         <span className="truncate text-xs text-muted-foreground">{project.path}</span>
+                        {isUnread && (
+                          <span className="text-xs text-muted-foreground">
+                            {t('project:tooltip.unreadTaskUpdates')}
+                          </span>
+                        )}
                       </div>
                     </TooltipContent>
                   </Tooltip>

--- a/src/renderer/projectTaskState.test.ts
+++ b/src/renderer/projectTaskState.test.ts
@@ -1,0 +1,375 @@
+import { describe, expect, it } from 'vitest'
+import type { WorkflowRuntimeStatus, WorkflowRuntimeState } from '../shared/workflowRuntime'
+import type { ProjectRecord, TaskRecord } from './appTypes'
+import {
+  createProjectTaskState,
+  getTaskObservationVersion,
+  projectTaskReducer,
+  selectCurrentProjectTasks,
+  type ProjectTaskAction,
+  type ProjectTaskState
+} from './projectTaskState'
+
+const projectA = project('a')
+const projectB = project('b')
+const projectC = project('c')
+
+function project(id: string): ProjectRecord {
+  return {
+    id,
+    name: `Project ${id}`,
+    path: `/repo/${id}`,
+    sort_order: 0,
+    created_at: '2026-01-01T00:00:00.000Z'
+  }
+}
+
+function task(
+  projectId: string,
+  id: string,
+  status: WorkflowRuntimeStatus = 'running',
+  updatedAt = '2026-01-01T00:00:00.000Z'
+): TaskRecord {
+  return {
+    id,
+    project_id: projectId,
+    title: `Task ${id}`,
+    status,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: updatedAt
+  }
+}
+
+function runtime(
+  record: TaskRecord,
+  options: {
+    status?: WorkflowRuntimeStatus
+    includeTask?: boolean
+    updatedAt?: string
+  } = {}
+): WorkflowRuntimeState {
+  const status = options.status ?? record.status
+  return {
+    taskId: record.id,
+    projectId: record.project_id,
+    projectDir: `/repo/${record.project_id}`,
+    workflowId: 'workflow',
+    status,
+    currentNodeId: 'start',
+    variables: {},
+    nodeRuns: {},
+    executionOrder: [],
+    activeBranches: [],
+    branchRuns: {},
+    parallelResults: {},
+    workflowCompleted: status === 'completed',
+    ...(options.includeTask === false ? {} : {
+      task: {
+        ...record,
+        status,
+        updated_at: options.updatedAt ?? record.updated_at
+      }
+    })
+  }
+}
+
+function reduce(state: ProjectTaskState, ...actions: ProjectTaskAction[]): ProjectTaskState {
+  return actions.reduce(projectTaskReducer, state)
+}
+
+function readyState(tasks: TaskRecord[] = [task('a', 'a-1')]): ProjectTaskState {
+  return reduce(
+    createProjectTaskState(),
+    { type: 'syncProjects', projects: [projectA, projectB, projectC] },
+    { type: 'activateProject', projectId: 'a', activationId: 1 },
+    { type: 'listStarted', projectId: 'a', activationId: 1, requestId: 1 },
+    { type: 'listSucceeded', projectId: 'a', activationId: 1, requestId: 1, tasks }
+  )
+}
+
+describe('projectTaskReducer', () => {
+  it('isolates every background status and marks only its owning project unread', () => {
+    let state = readyState()
+    const statuses: WorkflowRuntimeStatus[] = [
+      'running',
+      'waiting-input',
+      'completed',
+      'failed',
+      'stopped',
+      'interrupted'
+    ]
+    for (const status of statuses) {
+      const backgroundTask = task('b', 'b-1', status, `2026-01-01T00:00:0${statuses.indexOf(status)}.000Z`)
+      state = projectTaskReducer(state, {
+        type: 'runtimeReceived',
+        state: runtime(backgroundTask),
+        source: 'event',
+        moveTaskToFront: true
+      })
+      expect(selectCurrentProjectTasks(state, 'a').map((item) => item.id)).toEqual(['a-1'])
+      expect(state.unreadProjectIds).toEqual(new Set(['b']))
+    }
+  })
+
+  it('deduplicates the same background status while accepting a real transition after clearing', () => {
+    const backgroundTask = task('b', 'b-1')
+    let state = readyState()
+    state = projectTaskReducer(state, {
+      type: 'runtimeReceived',
+      state: runtime(backgroundTask),
+      source: 'event',
+      moveTaskToFront: true
+    })
+    state = reduce(
+      state,
+      { type: 'activateProject', projectId: 'b', activationId: 2 },
+      { type: 'listStarted', projectId: 'b', activationId: 2, requestId: 2 },
+      { type: 'listSucceeded', projectId: 'b', activationId: 2, requestId: 2, tasks: [backgroundTask] },
+      { type: 'activateProject', projectId: 'a', activationId: 3 },
+      { type: 'listStarted', projectId: 'a', activationId: 3, requestId: 3 },
+      { type: 'listSucceeded', projectId: 'a', activationId: 3, requestId: 3, tasks: [task('a', 'a-1')] }
+    )
+    state = projectTaskReducer(state, {
+      type: 'runtimeReceived',
+      state: runtime(backgroundTask, { updatedAt: '2026-01-02T00:00:00.000Z' }),
+      source: 'command',
+      moveTaskToFront: true
+    })
+    expect(state.unreadProjectIds.has('b')).toBe(false)
+
+    state = projectTaskReducer(state, {
+      type: 'runtimeReceived',
+      state: runtime(backgroundTask, { status: 'completed', updatedAt: '2026-01-03T00:00:00.000Z' }),
+      source: 'event',
+      moveTaskToFront: true
+    })
+    expect(state.unreadProjectIds).toEqual(new Set(['b']))
+  })
+
+  it('updates another task in the current project without unread or changing selection concerns', () => {
+    const first = task('a', 'a-1')
+    const second = task('a', 'a-2')
+    const state = projectTaskReducer(readyState([first, second]), {
+      type: 'runtimeReceived',
+      state: runtime(second, { status: 'completed', updatedAt: '2026-01-02T00:00:00.000Z' }),
+      source: 'event',
+      moveTaskToFront: true
+    })
+    expect(state.tasks.map((item) => [item.id, item.status])).toEqual([
+      ['a-2', 'completed'],
+      ['a-1', 'running']
+    ])
+    expect(state.unreadProjectIds.size).toBe(0)
+  })
+
+  it('keeps unread through loading and failure, then clears it atomically on success', () => {
+    const backgroundTask = task('b', 'b-1')
+    let state = projectTaskReducer(readyState(), {
+      type: 'runtimeReceived',
+      state: runtime(backgroundTask),
+      source: 'event',
+      moveTaskToFront: true
+    })
+    state = reduce(
+      state,
+      { type: 'activateProject', projectId: 'b', activationId: 2 },
+      { type: 'listStarted', projectId: 'b', activationId: 2, requestId: 2 }
+    )
+    expect(state.unreadProjectIds.has('b')).toBe(true)
+    state = projectTaskReducer(state, {
+      type: 'listFailed', projectId: 'b', activationId: 2, requestId: 2
+    })
+    expect(state.unreadProjectIds.has('b')).toBe(true)
+    state = projectTaskReducer(state, {
+      type: 'runtimeReceived',
+      state: runtime(backgroundTask, {
+        status: 'completed',
+        updatedAt: '2026-01-02T00:00:00.000Z'
+      }),
+      source: 'event',
+      moveTaskToFront: true
+    })
+    state = reduce(
+      state,
+      { type: 'listStarted', projectId: 'b', activationId: 2, requestId: 3 },
+      { type: 'listSucceeded', projectId: 'b', activationId: 2, requestId: 3, tasks: [backgroundTask] }
+    )
+    expect(state.phase).toBe('ready')
+    expect(state.tasks[0].status).toBe('completed')
+    expect(state.unreadProjectIds.has('b')).toBe(false)
+  })
+
+  it('rejects stale A responses across A to B to A navigation', () => {
+    let state = readyState()
+    state = reduce(
+      state,
+      { type: 'activateProject', projectId: 'b', activationId: 2 },
+      { type: 'listStarted', projectId: 'b', activationId: 2, requestId: 2 },
+      { type: 'activateProject', projectId: 'a', activationId: 3 },
+      { type: 'listStarted', projectId: 'a', activationId: 3, requestId: 3 }
+    )
+    const stale = projectTaskReducer(state, {
+      type: 'listSucceeded',
+      projectId: 'a',
+      activationId: 1,
+      requestId: 1,
+      tasks: [task('a', 'stale')]
+    })
+    expect(stale).toBe(state)
+    const current = projectTaskReducer(state, {
+      type: 'listSucceeded',
+      projectId: 'a',
+      activationId: 3,
+      requestId: 3,
+      tasks: [task('a', 'current')]
+    })
+    expect(current.tasks.map((item) => item.id)).toEqual(['current'])
+  })
+
+  it('merges runtime, rename, deletion and foreign filtering into a pending list snapshot', () => {
+    let state = reduce(
+      createProjectTaskState(),
+      { type: 'syncProjects', projects: [projectA, projectB] },
+      { type: 'activateProject', projectId: 'a', activationId: 1 },
+      { type: 'listStarted', projectId: 'a', activationId: 1, requestId: 1 }
+    )
+    const updated = task('a', 'updated', 'completed', '2026-01-03T00:00:00.000Z')
+    const created = task('a', 'created', 'running', '2026-01-04T00:00:00.000Z')
+    state = reduce(
+      state,
+      {
+        type: 'runtimeReceived',
+        state: runtime(updated),
+        source: 'event',
+        moveTaskToFront: true
+      },
+      {
+        type: 'runtimeReceived',
+        state: runtime(created),
+        source: 'event',
+        moveTaskToFront: true
+      },
+      { type: 'taskRenamed', projectId: 'a', taskId: 'updated', title: 'Renamed' },
+      { type: 'taskDeleted', projectId: 'a', taskId: 'deleted' }
+    )
+    state = projectTaskReducer(state, {
+      type: 'listSucceeded',
+      projectId: 'a',
+      activationId: 1,
+      requestId: 1,
+      tasks: [
+        task('a', 'updated', 'waiting-input'),
+        task('a', 'deleted'),
+        task('b', 'foreign')
+      ]
+    })
+    expect(state.tasks.map((item) => [item.id, item.title, item.status])).toEqual([
+      ['created', 'Task created', 'running'],
+      ['updated', 'Renamed', 'completed']
+    ])
+  })
+
+  it('tracks missing summaries without creating blank tasks and ignores invalid identities', () => {
+    const unknown = task('b', 'b-1')
+    let state = readyState()
+    state = projectTaskReducer(state, {
+      type: 'runtimeReceived',
+      state: runtime(unknown, { includeTask: false }),
+      source: 'event',
+      moveTaskToFront: true
+    })
+    expect(state.unreadProjectIds.has('b')).toBe(true)
+    expect(state.tasks.map((item) => item.id)).toEqual(['a-1'])
+
+    const invalid = { ...runtime(unknown), projectId: 'unknown' }
+    expect(projectTaskReducer(state, {
+      type: 'runtimeReceived', state: invalid, source: 'event', moveTaskToFront: true
+    })).toBe(state)
+    const mismatched = {
+      ...runtime(unknown),
+      task: { ...runtime(unknown).task!, project_id: 'a' }
+    }
+    expect(projectTaskReducer(state, {
+      type: 'runtimeReceived', state: mismatched, source: 'event', moveTaskToFront: true
+    })).toBe(state)
+  })
+
+  it('does not resurrect a deleted task from runtime or a late list', () => {
+    let state = projectTaskReducer(readyState(), {
+      type: 'taskDeleted', projectId: 'a', taskId: 'a-1'
+    })
+    state = projectTaskReducer(state, {
+      type: 'runtimeReceived',
+      state: runtime(task('a', 'a-1', 'completed')),
+      source: 'event',
+      moveTaskToFront: true
+    })
+    expect(state.tasks).toEqual([])
+    state = reduce(
+      state,
+      { type: 'listStarted', projectId: 'a', activationId: 1, requestId: 2 },
+      {
+        type: 'listSucceeded',
+        projectId: 'a',
+        activationId: 1,
+        requestId: 2,
+        tasks: [task('a', 'a-1')]
+      }
+    )
+    expect(state.tasks).toEqual([])
+  })
+
+  it('does not let an old snapshot or restore overwrite a newer event', () => {
+    const initial = task('a', 'a-1', 'running', '2026-01-02T00:00:00.000Z')
+    let state = readyState([initial])
+    const restoreVersion = getTaskObservationVersion(state, 'a', 'a-1')
+    state = projectTaskReducer(state, {
+      type: 'runtimeReceived',
+      state: runtime(initial, { status: 'completed', updatedAt: '2026-01-04T00:00:00.000Z' }),
+      source: 'event',
+      moveTaskToFront: true
+    })
+    const afterEvent = state
+    state = projectTaskReducer(state, {
+      type: 'runtimeReceived',
+      state: runtime(initial, { status: 'waiting-input', updatedAt: '2026-01-03T00:00:00.000Z' }),
+      source: 'event',
+      moveTaskToFront: true
+    })
+    expect(state).toBe(afterEvent)
+    state = projectTaskReducer(state, {
+      type: 'runtimeReceived',
+      state: runtime(initial, { status: 'running', updatedAt: '2026-01-05T00:00:00.000Z' }),
+      source: 'restore',
+      moveTaskToFront: false,
+      observationVersion: restoreVersion
+    })
+    expect(state).toBe(afterEvent)
+    expect(state.tasks[0].status).toBe('completed')
+  })
+
+  it('cleans observations and unread state only when a project is removed', () => {
+    const backgroundTask = task('b', 'b-1')
+    let state = projectTaskReducer(readyState(), {
+      type: 'runtimeReceived',
+      state: runtime(backgroundTask),
+      source: 'event',
+      moveTaskToFront: true
+    })
+    const version = getTaskObservationVersion(state, 'b', 'b-1')
+    state = projectTaskReducer(state, {
+      type: 'syncProjects', projects: [projectC, projectA, projectB]
+    })
+    expect(state.unreadProjectIds.has('b')).toBe(true)
+    expect(getTaskObservationVersion(state, 'b', 'b-1')).toBe(version)
+
+    state = projectTaskReducer(state, { type: 'syncProjects', projects: [projectA, projectC] })
+    expect(state.unreadProjectIds.has('b')).toBe(false)
+    expect(getTaskObservationVersion(state, 'b', 'b-1')).toBe(0)
+
+    state = projectTaskReducer(state, { type: 'syncProjects', projects: [projectC] })
+    expect(state.projectId).toBeNull()
+    expect(state.tasks).toEqual([])
+    expect(state.phase).toBe('idle')
+  })
+})

--- a/src/renderer/projectTaskState.ts
+++ b/src/renderer/projectTaskState.ts
@@ -1,0 +1,466 @@
+import type {
+  WorkflowRuntimeState,
+  WorkflowRuntimeStatus,
+  WorkflowRuntimeTaskSnapshot
+} from '../shared/workflowRuntime'
+import type { ProjectRecord, TaskRecord } from './appTypes'
+import { mergeTaskRecord } from './utils'
+
+export type RuntimeStateSource = 'event' | 'command' | 'restore'
+export type ProjectTaskLoadPhase = 'idle' | 'loading' | 'ready' | 'error'
+
+type TaskObservation = {
+  status: WorkflowRuntimeStatus
+  updatedAt?: string
+  version: number
+}
+
+type LoadingTaskPatch = {
+  snapshot?: WorkflowRuntimeTaskSnapshot
+  status?: WorkflowRuntimeStatus
+  title?: string
+  moveToFrontOrder?: number
+}
+
+export type ProjectTaskState = {
+  knownProjectIds: ReadonlySet<string>
+  projectId: string | null
+  activationId: number
+  requestId: number | null
+  phase: ProjectTaskLoadPhase
+  tasks: TaskRecord[]
+  observations: ReadonlyMap<string, TaskObservation>
+  unreadProjectIds: ReadonlySet<string>
+  loadingPatches: ReadonlyMap<string, LoadingTaskPatch>
+  deletedTaskKeys: ReadonlySet<string>
+  observationVersion: number
+  receiveOrder: number
+}
+
+type RuntimeReceivedAction = {
+  type: 'runtimeReceived'
+  state: WorkflowRuntimeState
+  source: RuntimeStateSource
+  moveTaskToFront: boolean
+  observationVersion?: number
+}
+
+export type ProjectTaskAction =
+  | { type: 'syncProjects'; projects: ProjectRecord[] }
+  | { type: 'activateProject'; projectId: string | null; activationId: number }
+  | { type: 'listStarted'; projectId: string; activationId: number; requestId: number }
+  | {
+      type: 'listSucceeded'
+      projectId: string
+      activationId: number
+      requestId: number
+      tasks: TaskRecord[]
+    }
+  | { type: 'listFailed'; projectId: string; activationId: number; requestId: number }
+  | RuntimeReceivedAction
+  | { type: 'taskRenamed'; projectId: string; taskId: string; title: string }
+  | { type: 'taskDeleted'; projectId: string; taskId: string }
+
+function taskKey(projectId: string, taskId: string): string {
+  return `${projectId}\u0000${taskId}`
+}
+
+function keyBelongsToProject(key: string, projectId: string): boolean {
+  return key.startsWith(`${projectId}\u0000`)
+}
+
+function isOlderTimestamp(incoming: string | undefined, existing: string | undefined): boolean {
+  if (!incoming || !existing) return false
+  return incoming < existing
+}
+
+function snapshotUpdatedAt(state: WorkflowRuntimeState): string | undefined {
+  return state.task?.updated_at
+}
+
+function snapshotsEqual(
+  left: WorkflowRuntimeTaskSnapshot | undefined,
+  right: WorkflowRuntimeTaskSnapshot | undefined
+): boolean {
+  if (left === right) return true
+  if (!left || !right) return false
+  return left.id === right.id &&
+    left.project_id === right.project_id &&
+    left.title === right.title &&
+    left.status === right.status &&
+    left.created_at === right.created_at &&
+    left.updated_at === right.updated_at
+}
+
+function mergeSnapshotIntoTask(
+  task: TaskRecord,
+  snapshot: WorkflowRuntimeTaskSnapshot | undefined,
+  status: WorkflowRuntimeStatus
+): TaskRecord {
+  return {
+    ...task,
+    ...(snapshot ? {
+      title: snapshot.title,
+      ...(snapshot.created_at ? { created_at: snapshot.created_at } : {}),
+      ...(snapshot.updated_at ? { updated_at: snapshot.updated_at } : {})
+    } : {}),
+    status
+  }
+}
+
+function taskFromSnapshot(
+  snapshot: WorkflowRuntimeTaskSnapshot | undefined,
+  status: WorkflowRuntimeStatus
+): TaskRecord | null {
+  if (!snapshot?.created_at || !snapshot.updated_at) return null
+  return {
+    id: snapshot.id,
+    project_id: snapshot.project_id,
+    title: snapshot.title,
+    status,
+    created_at: snapshot.created_at,
+    updated_at: snapshot.updated_at
+  }
+}
+
+function updateCurrentTasks(
+  tasks: TaskRecord[],
+  runtimeState: WorkflowRuntimeState,
+  moveTaskToFront: boolean
+): TaskRecord[] {
+  const existing = tasks.find((task) => task.id === runtimeState.taskId)
+  const task = existing
+    ? mergeSnapshotIntoTask(existing, runtimeState.task, runtimeState.status)
+    : taskFromSnapshot(runtimeState.task, runtimeState.status)
+  if (!task) return tasks
+
+  const alreadyEqual = existing &&
+    existing.project_id === task.project_id &&
+    existing.title === task.title &&
+    existing.status === task.status &&
+    existing.created_at === task.created_at &&
+    existing.updated_at === task.updated_at
+  if (alreadyEqual && (!moveTaskToFront || tasks[0]?.id === task.id)) return tasks
+  return mergeTaskRecord(tasks, task, moveTaskToFront)
+}
+
+function isCurrentRequest(
+  state: ProjectTaskState,
+  action: { projectId: string; activationId: number; requestId: number }
+): boolean {
+  return state.projectId === action.projectId &&
+    state.activationId === action.activationId &&
+    state.requestId === action.requestId
+}
+
+export function createProjectTaskState(): ProjectTaskState {
+  return {
+    knownProjectIds: new Set(),
+    projectId: null,
+    activationId: 0,
+    requestId: null,
+    phase: 'idle',
+    tasks: [],
+    observations: new Map(),
+    unreadProjectIds: new Set(),
+    loadingPatches: new Map(),
+    deletedTaskKeys: new Set(),
+    observationVersion: 0,
+    receiveOrder: 0
+  }
+}
+
+export function isRuntimeStateIdentityValid(
+  state: ProjectTaskState,
+  runtimeState: WorkflowRuntimeState
+): boolean {
+  if (!state.knownProjectIds.has(runtimeState.projectId)) return false
+  if (!runtimeState.task) return true
+  return runtimeState.task.id === runtimeState.taskId &&
+    runtimeState.task.project_id === runtimeState.projectId
+}
+
+export function canApplyRuntimeState(
+  state: ProjectTaskState,
+  runtimeState: WorkflowRuntimeState,
+  source: RuntimeStateSource,
+  observationVersion?: number
+): boolean {
+  if (!isRuntimeStateIdentityValid(state, runtimeState)) return false
+  const key = taskKey(runtimeState.projectId, runtimeState.taskId)
+  if (state.deletedTaskKeys.has(key)) return false
+  const observed = state.observations.get(key)
+  if (isOlderTimestamp(snapshotUpdatedAt(runtimeState), observed?.updatedAt)) return false
+  if (source === 'restore' && observationVersion !== undefined) {
+    return (observed?.version ?? 0) === observationVersion
+  }
+  return true
+}
+
+export function getTaskObservationVersion(
+  state: ProjectTaskState,
+  projectId: string,
+  taskId: string
+): number {
+  return state.observations.get(taskKey(projectId, taskId))?.version ?? 0
+}
+
+export function selectCurrentProjectTasks(
+  state: ProjectTaskState,
+  activeProjectId: string | null
+): TaskRecord[] {
+  if (!activeProjectId || state.projectId !== activeProjectId) return []
+  return state.tasks.filter((task) => task.project_id === activeProjectId)
+}
+
+export function projectTaskReducer(
+  state: ProjectTaskState,
+  action: ProjectTaskAction
+): ProjectTaskState {
+  switch (action.type) {
+    case 'syncProjects': {
+      const knownProjectIds = new Set(action.projects.map((project) => project.id))
+      const observations = new Map(
+        [...state.observations].filter(([key]) => (
+          [...knownProjectIds].some((projectId) => keyBelongsToProject(key, projectId))
+        ))
+      )
+      const unreadProjectIds = new Set(
+        [...state.unreadProjectIds].filter((projectId) => knownProjectIds.has(projectId))
+      )
+      const deletedTaskKeys = new Set(
+        [...state.deletedTaskKeys].filter((key) => (
+          [...knownProjectIds].some((projectId) => keyBelongsToProject(key, projectId))
+        ))
+      )
+      const currentProjectRemoved = state.projectId !== null && !knownProjectIds.has(state.projectId)
+      const loadingPatches = !currentProjectRemoved
+        ? state.loadingPatches
+        : new Map<string, LoadingTaskPatch>()
+      return {
+        ...state,
+        knownProjectIds,
+        projectId: currentProjectRemoved ? null : state.projectId,
+        requestId: currentProjectRemoved ? null : state.requestId,
+        phase: currentProjectRemoved ? 'idle' : state.phase,
+        tasks: currentProjectRemoved ? [] : state.tasks,
+        observations,
+        unreadProjectIds,
+        loadingPatches,
+        deletedTaskKeys
+      }
+    }
+
+    case 'activateProject':
+      return {
+        ...state,
+        projectId: action.projectId,
+        activationId: action.activationId,
+        requestId: null,
+        phase: action.projectId ? 'loading' : 'idle',
+        tasks: [],
+        loadingPatches: new Map()
+      }
+
+    case 'listStarted':
+      if (
+        state.projectId !== action.projectId ||
+        state.activationId !== action.activationId ||
+        !state.knownProjectIds.has(action.projectId)
+      ) return state
+      return {
+        ...state,
+        requestId: action.requestId,
+        phase: 'loading'
+      }
+
+    case 'listSucceeded': {
+      if (!isCurrentRequest(state, action)) return state
+      const deletedTaskKeys = state.deletedTaskKeys
+      let tasks = action.tasks.filter((task) => (
+        task.project_id === action.projectId &&
+        !deletedTaskKeys.has(taskKey(action.projectId, task.id))
+      ))
+      const orderedPatches = [...state.loadingPatches.entries()].sort((left, right) => (
+        (left[1].moveToFrontOrder ?? -1) - (right[1].moveToFrontOrder ?? -1)
+      ))
+      for (const [taskId, patch] of orderedPatches) {
+        const key = taskKey(action.projectId, taskId)
+        if (deletedTaskKeys.has(key)) continue
+        const existing = tasks.find((task) => task.id === taskId)
+        let task = existing
+        if (patch.status) {
+          task = existing
+            ? mergeSnapshotIntoTask(existing, patch.snapshot, patch.status)
+            : taskFromSnapshot(patch.snapshot, patch.status) ?? undefined
+        }
+        if (task && patch.title !== undefined) task = { ...task, title: patch.title }
+        if (task) tasks = mergeTaskRecord(tasks, task, patch.moveToFrontOrder !== undefined)
+      }
+
+      const observations = new Map(state.observations)
+      let observationVersion = state.observationVersion
+      for (const task of tasks) {
+        const key = taskKey(action.projectId, task.id)
+        if (state.loadingPatches.has(task.id) && observations.has(key)) continue
+        observationVersion += 1
+        observations.set(key, {
+          status: task.status,
+          updatedAt: task.updated_at,
+          version: observationVersion
+        })
+      }
+      const unreadProjectIds = new Set(state.unreadProjectIds)
+      unreadProjectIds.delete(action.projectId)
+      return {
+        ...state,
+        tasks,
+        observations,
+        observationVersion,
+        unreadProjectIds,
+        loadingPatches: new Map(),
+        phase: 'ready'
+      }
+    }
+
+    case 'listFailed':
+      if (!isCurrentRequest(state, action)) return state
+      return {
+        ...state,
+        tasks: [...state.loadingPatches.entries()]
+          .sort((left, right) => (
+            (left[1].moveToFrontOrder ?? -1) - (right[1].moveToFrontOrder ?? -1)
+          ))
+          .reduce((tasks, [taskId, patch]) => {
+            if (!patch.status || state.deletedTaskKeys.has(taskKey(action.projectId, taskId))) {
+              return tasks
+            }
+            const existing = tasks.find((task) => task.id === taskId)
+            let task = existing
+              ? mergeSnapshotIntoTask(existing, patch.snapshot, patch.status)
+              : taskFromSnapshot(patch.snapshot, patch.status) ?? undefined
+            if (!task) return tasks
+            if (patch.title !== undefined) task = { ...task, title: patch.title }
+            return mergeTaskRecord(tasks, task, patch.moveToFrontOrder !== undefined)
+          }, state.tasks),
+        phase: 'error'
+      }
+
+    case 'runtimeReceived': {
+      if (!canApplyRuntimeState(
+        state,
+        action.state,
+        action.source,
+        action.observationVersion
+      )) return state
+
+      const runtimeState = action.state
+      const key = taskKey(runtimeState.projectId, runtimeState.taskId)
+      const previousObservation = state.observations.get(key)
+      const incomingUpdatedAt = snapshotUpdatedAt(runtimeState)
+      const observationChanged = action.source !== 'restore' ||
+        !previousObservation ||
+        previousObservation.status !== runtimeState.status ||
+        previousObservation.updatedAt !== (incomingUpdatedAt ?? previousObservation.updatedAt)
+      const observationVersion = observationChanged
+        ? state.observationVersion + 1
+        : state.observationVersion
+      const observations = observationChanged
+        ? new Map(state.observations).set(key, {
+            status: runtimeState.status,
+            updatedAt: incomingUpdatedAt ?? previousObservation?.updatedAt,
+            version: observationVersion
+          })
+        : state.observations
+      const isCurrentProject = state.projectId === runtimeState.projectId
+      let unreadProjectIds = state.unreadProjectIds
+      if (
+        action.source !== 'restore' &&
+        !isCurrentProject &&
+        (!previousObservation || previousObservation.status !== runtimeState.status) &&
+        !state.unreadProjectIds.has(runtimeState.projectId)
+      ) {
+        unreadProjectIds = new Set(state.unreadProjectIds).add(runtimeState.projectId)
+      }
+
+      let tasks = state.tasks
+      let loadingPatches = state.loadingPatches
+      let receiveOrder = state.receiveOrder
+      if (isCurrentProject) {
+        if (state.phase === 'loading' || state.phase === 'error') {
+          const previousPatch = state.loadingPatches.get(runtimeState.taskId)
+          receiveOrder = action.moveTaskToFront ? state.receiveOrder + 1 : state.receiveOrder
+          const nextPatch: LoadingTaskPatch = {
+            ...previousPatch,
+            snapshot: runtimeState.task ?? previousPatch?.snapshot,
+            status: runtimeState.status,
+            ...(action.moveTaskToFront ? { moveToFrontOrder: receiveOrder } : {})
+          }
+          if (
+            previousPatch?.status !== nextPatch.status ||
+            previousPatch?.moveToFrontOrder !== nextPatch.moveToFrontOrder ||
+            !snapshotsEqual(previousPatch?.snapshot, nextPatch.snapshot)
+          ) {
+            loadingPatches = new Map(state.loadingPatches).set(runtimeState.taskId, nextPatch)
+          }
+        }
+        if (state.phase !== 'loading') {
+          tasks = updateCurrentTasks(state.tasks, runtimeState, action.moveTaskToFront)
+        }
+      }
+
+      if (
+        observations === state.observations &&
+        unreadProjectIds === state.unreadProjectIds &&
+        tasks === state.tasks &&
+        loadingPatches === state.loadingPatches
+      ) return state
+      return {
+        ...state,
+        tasks,
+        observations,
+        observationVersion,
+        unreadProjectIds,
+        loadingPatches,
+        receiveOrder
+      }
+    }
+
+    case 'taskRenamed': {
+      if (!state.knownProjectIds.has(action.projectId)) return state
+      let tasks = state.tasks
+      let loadingPatches = state.loadingPatches
+      if (state.projectId === action.projectId) {
+        tasks = state.tasks.map((task) => (
+          task.id === action.taskId ? { ...task, title: action.title } : task
+        ))
+        if (state.phase === 'loading' || state.phase === 'error') {
+          const previousPatch = state.loadingPatches.get(action.taskId) ?? {}
+          loadingPatches = new Map(state.loadingPatches).set(action.taskId, {
+            ...previousPatch,
+            title: action.title
+          })
+        }
+      }
+      if (tasks === state.tasks && loadingPatches === state.loadingPatches) return state
+      return { ...state, tasks, loadingPatches }
+    }
+
+    case 'taskDeleted': {
+      if (!state.knownProjectIds.has(action.projectId)) return state
+      const key = taskKey(action.projectId, action.taskId)
+      const deletedTaskKeys = new Set(state.deletedTaskKeys).add(key)
+      const observations = new Map(state.observations)
+      observations.delete(key)
+      let tasks = state.tasks
+      let loadingPatches = state.loadingPatches
+      if (state.projectId === action.projectId) {
+        tasks = state.tasks.filter((task) => task.id !== action.taskId)
+        const nextLoadingPatches = new Map(state.loadingPatches)
+        nextLoadingPatches.delete(action.taskId)
+        loadingPatches = nextLoadingPatches
+      }
+      return { ...state, deletedTaskKeys, observations, tasks, loadingPatches }
+    }
+  }
+}

--- a/src/shared/i18n/locales/en.ts
+++ b/src/shared/i18n/locales/en.ts
@@ -432,11 +432,13 @@ export default {
   project: {
     action: {
       openProject: 'Open project {{name}}',
+      openProjectWithUnread: 'Open project {{name}}, unread task status updates',
       deleteProject: 'Delete project {{name}}',
       addFolder: 'Add project folder'
     },
     tooltip: {
-      deleteProject: 'Delete project'
+      deleteProject: 'Delete project',
+      unreadTaskUpdates: 'Unread task status updates'
     },
     rename: {
       title: 'Rename project',

--- a/src/shared/i18n/locales/zh.ts
+++ b/src/shared/i18n/locales/zh.ts
@@ -432,11 +432,13 @@ export default {
   project: {
     action: {
       openProject: '打开项目 {{name}}',
+      openProjectWithUnread: '打开项目 {{name}}，有未读任务状态更新',
       deleteProject: '删除项目 {{name}}',
       addFolder: '添加项目文件夹'
     },
     tooltip: {
-      deleteProject: '删除项目'
+      deleteProject: '删除项目',
+      unreadTaskUpdates: '有未读任务状态更新'
     },
     rename: {
       title: '重命名项目',


### PR DESCRIPTION
Replace the flat task list with a projectTaskState reducer that scopes
tasks to the active project, discards stale runtime events from switched
projects or deleted tasks, and merges loading-time updates into list
results without races. Also badge projects with unread background task
status changes.
